### PR TITLE
Time distributed control

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install graphviz
-        run: apt update && apt install -y graphviz
+        run: apt update && apt install -y graphviz-dev
         
       - name: Install dependencies
         run: python3 -m pip install ".[docs]"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install graphviz
+        run: apt update && apt install -y graphviz
         
       - name: Install dependencies
         run: python3 -m pip install ".[docs]"

--- a/_toc.yml
+++ b/_toc.yml
@@ -5,6 +5,7 @@ parts:
   - caption: Examples
     chapters:
     - file: "demos/poisson_mother.py"
+    - file: "demos/time_distributed_control.py"
   - caption: Python API
     chapters:
     - file: "docs/api"

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -1,0 +1,97 @@
+from mpi4py import MPI
+import dolfinx
+import dolfinx_adjoint
+import ufl
+import numpy as np
+from collections import OrderedDict
+
+mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
+x = ufl.SpatialCoordinate(mesh)
+# FIXME: Until constant is taped we need to use Function
+nu = dolfinx.fem.Constant(mesh, 1e-5)
+nu.name = "nu"  # type: ignore
+Q = dolfinx.fem.functionspace(mesh, ("DG", 0))  # type: ignore[arg-type]
+t = dolfinx_adjoint.Function(Q)
+t.name = "time"
+d = 16*x[0]*(x[0]-1)*x[1]*(x[1]-1)*ufl.sin(ufl.pi*t)
+
+dt = dolfinx.fem.Constant(mesh, dolfinx.default_scalar_type(0.1))
+T = 1
+
+V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))  # type: ignore[arg-type]
+ctrls = OrderedDict()
+t_val = float(dt)
+while t_val <= T:
+    ctrls[t_val] = dolfinx_adjoint.Function(V, name=f"control_{t_val}")
+    t_val += float(dt)
+
+
+
+def solve_heat(ctrls):
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+
+    f = dolfinx_adjoint.Function(V, name="source")
+    u_0 = dolfinx_adjoint.Function(V, name="solution")
+
+    F = ( (u - u_0)/dt*v + nu*ufl.inner(ufl.grad(u), ufl.grad(v)) - f*v)*ufl.dx
+    a, L = ufl.system(F)
+    mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
+    exterior_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)
+    exterior_dofs = dolfinx.fem.locate_dofs_topological(V, mesh.topology.dim - 1, exterior_facets)
+
+    bc = dolfinx.fem.dirichletbc(0.0, exterior_dofs, V)
+
+    j = 0.5*float(dt)*dolfinx_adjoint.assemble_scalar((u_0 - d)**2*ufl.dx)
+
+    t_val = float(dt)
+    problem = dolfinx_adjoint.LinearProblem(a, L, u=u_0, bcs=[bc], petsc_options={"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True},
+                                        adjoint_petsc_options={"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True},
+                                        tlm_petsc_options={"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True})
+    dolfinx_adjoint.assign(t_val, t)
+    while t_val <= T:
+        # Update source term from control array
+        dolfinx_adjoint.assign(ctrls[t_val], f)
+
+        # Update data function
+
+        # Solve PDE
+        problem.solve()
+
+        # Implement a trapezoidal rule
+        if t_val > T - float(dt):
+           weight = 0.5
+        else:
+           weight = 1
+        j += weight*float(dt)*dolfinx_adjoint.assemble_scalar((u_0 - d)**2*ufl.dx)
+        # Update time
+        t_val += float(dt)
+        dolfinx_adjoint.assign(t_val, t)
+        
+    return u_0, d, j
+
+u, d, j = solve_heat(ctrls)
+
+alpha = dolfinx.fem.Constant(mesh, 1.e-1)
+regularisation = alpha/2*sum([1/dt*(fb-fa)**2*ufl.dx for fb, fa in
+    zip(list(ctrls.values())[1:], list(ctrls.values())[:-1])])
+
+import pyadjoint
+J = j + dolfinx_adjoint.assemble_scalar(regularisation)
+m = [pyadjoint.Control(c) for c in ctrls.values()]
+
+
+rf = pyadjoint.ReducedFunctional(J, m)
+
+tape = pyadjoint.get_working_tape()
+tape.visualise_dot("test.dot")
+
+opt_ctrls = pyadjoint.minimize(rf,             method="BFGS",
+    #method="Newton-CG",
+options={"maxiter": 50, "disp": True})
+
+out_ctrl = dolfinx.fem.Function(V, name="optimal_control")
+with dolfinx.io.VTXWriter(mesh.comm, "opt_ctrl.bp", [out_ctrl]) as vtx:
+    for t_val, c in zip(ctrls.keys(), opt_ctrls):
+        out_ctrl.x.array[:] = c.x.array[:]
+        vtx.write(t_val)

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -126,3 +126,6 @@ with dolfinx.io.VTXWriter(mesh.comm, "opt_ctrl.bp", [out_ctrl]) as vtx:
     for t_val, c in zip(ctrls.keys(), opt_ctrls):
         out_ctrl.x.array[:] = c.x.array[:]
         vtx.write(t_val)
+
+assert np.isclose(np.linalg.norm(opt_ctrls[0].x.array), 4.925369634)
+assert np.isclose(np.linalg.norm(opt_ctrls[-1].x.array), 2.871728934)

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -1,3 +1,6 @@
+# # Time-distributed control
+# Based on example from https://dolfin-adjoint.github.io/dolfin-adjoint/documentation/time-distributed-control/time-distributed-control.html
+
 from mpi4py import MPI
 import dolfinx
 import dolfinx_adjoint
@@ -13,7 +16,7 @@ nu.name = "nu"  # type: ignore
 Q = dolfinx.fem.functionspace(mesh, ("DG", 0))  # type: ignore[arg-type]
 t = dolfinx_adjoint.Function(Q)
 t.name = "time"
-d = 16*x[0]*(x[0]-1)*x[1]*(x[1]-1)*ufl.sin(ufl.pi*t)
+d = 16 * x[0] * (x[0] - 1) * x[1] * (x[1] - 1) * ufl.sin(ufl.pi * t)
 
 dt = dolfinx.fem.Constant(mesh, dolfinx.default_scalar_type(0.1))
 T = 1
@@ -26,7 +29,6 @@ while t_val <= T:
     t_val += float(dt)
 
 
-
 def solve_heat(ctrls):
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
@@ -34,7 +36,7 @@ def solve_heat(ctrls):
     f = dolfinx_adjoint.Function(V, name="source")
     u_0 = dolfinx_adjoint.Function(V, name="solution")
 
-    F = ( (u - u_0)/dt*v + nu*ufl.inner(ufl.grad(u), ufl.grad(v)) - f*v)*ufl.dx
+    F = ((u - u_0) / dt * v + nu * ufl.inner(ufl.grad(u), ufl.grad(v)) - f * v) * ufl.dx
     a, L = ufl.system(F)
     mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
     exterior_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)
@@ -42,12 +44,33 @@ def solve_heat(ctrls):
 
     bc = dolfinx.fem.dirichletbc(0.0, exterior_dofs, V)
 
-    j = 0.5*float(dt)*dolfinx_adjoint.assemble_scalar((u_0 - d)**2*ufl.dx)
+    j = 0.5 * float(dt) * dolfinx_adjoint.assemble_scalar((u_0 - d) ** 2 * ufl.dx)
 
     t_val = float(dt)
-    problem = dolfinx_adjoint.LinearProblem(a, L, u=u_0, bcs=[bc], petsc_options={"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True},
-                                        adjoint_petsc_options={"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True},
-                                        tlm_petsc_options={"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True})
+    problem = dolfinx_adjoint.LinearProblem(
+        a,
+        L,
+        u=u_0,
+        bcs=[bc],
+        petsc_options={
+            "ksp_type": "preonly",
+            "pc_type": "lu",
+            "pc_factor_mat_solver_type": "mumps",
+            "ksp_error_if_not_converged": True,
+        },
+        adjoint_petsc_options={
+            "ksp_type": "preonly",
+            "pc_type": "lu",
+            "pc_factor_mat_solver_type": "mumps",
+            "ksp_error_if_not_converged": True,
+        },
+        tlm_petsc_options={
+            "ksp_type": "preonly",
+            "pc_type": "lu",
+            "pc_factor_mat_solver_type": "mumps",
+            "ksp_error_if_not_converged": True,
+        },
+    )
     dolfinx_adjoint.assign(t_val, t)
     while t_val <= T:
         # Update source term from control array
@@ -60,23 +83,28 @@ def solve_heat(ctrls):
 
         # Implement a trapezoidal rule
         if t_val > T - float(dt):
-           weight = 0.5
+            weight = 0.5
         else:
-           weight = 1
-        j += weight*float(dt)*dolfinx_adjoint.assemble_scalar((u_0 - d)**2*ufl.dx)
+            weight = 1
+        j += weight * float(dt) * dolfinx_adjoint.assemble_scalar((u_0 - d) ** 2 * ufl.dx)
         # Update time
         t_val += float(dt)
         dolfinx_adjoint.assign(t_val, t)
-        
+
     return u_0, d, j
+
 
 u, d, j = solve_heat(ctrls)
 
-alpha = dolfinx.fem.Constant(mesh, 1.e-1)
-regularisation = alpha/2*sum([1/dt*(fb-fa)**2*ufl.dx for fb, fa in
-    zip(list(ctrls.values())[1:], list(ctrls.values())[:-1])])
+alpha = dolfinx.fem.Constant(mesh, 1.0e-1)
+regularisation = (
+    alpha
+    / 2
+    * sum([1 / dt * (fb - fa) ** 2 * ufl.dx for fb, fa in zip(list(ctrls.values())[1:], list(ctrls.values())[:-1])])
+)
 
 import pyadjoint
+
 J = j + dolfinx_adjoint.assemble_scalar(regularisation)
 m = [pyadjoint.Control(c) for c in ctrls.values()]
 
@@ -86,9 +114,12 @@ rf = pyadjoint.ReducedFunctional(J, m)
 tape = pyadjoint.get_working_tape()
 tape.visualise_dot("test.dot")
 
-opt_ctrls = pyadjoint.minimize(rf,             method="BFGS",
-    #method="Newton-CG",
-options={"maxiter": 50, "disp": True})
+opt_ctrls = pyadjoint.minimize(
+    rf,
+    method="BFGS",
+    # method="Newton-CG",
+    options={"maxiter": 50, "disp": True},
+)
 
 out_ctrl = dolfinx.fem.Function(V, name="optimal_control")
 with dolfinx.io.VTXWriter(mesh.comm, "opt_ctrl.bp", [out_ctrl]) as vtx:

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -1,12 +1,16 @@
 # # Time-distributed control
 # Based on example from https://dolfin-adjoint.github.io/dolfin-adjoint/documentation/time-distributed-control/time-distributed-control.html
 
-from mpi4py import MPI
-import dolfinx
-import dolfinx_adjoint
-import ufl
-import numpy as np
 from collections import OrderedDict
+
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pyadjoint
+import ufl
+
+import dolfinx_adjoint
 
 mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
 x = ufl.SpatialCoordinate(mesh)
@@ -103,7 +107,6 @@ regularisation = (
     * sum([1 / dt * (fb - fa) ** 2 * ufl.dx for fb, fa in zip(list(ctrls.values())[1:], list(ctrls.values())[:-1])])
 )
 
-import pyadjoint
 
 J = j + dolfinx_adjoint.assemble_scalar(regularisation)
 m = [pyadjoint.Control(c) for c in ctrls.values()]

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -15,7 +15,7 @@ import dolfinx_adjoint
 mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
 x = ufl.SpatialCoordinate(mesh)
 # FIXME: Until constant is taped we need to use Function
-nu = dolfinx.fem.Constant(mesh, 1e-5)
+nu = dolfinx.fem.Constant(mesh, np.float64(1e-5))
 nu.name = "nu"  # type: ignore
 Q = dolfinx.fem.functionspace(mesh, ("DG", 0))  # type: ignore[arg-type]
 t = dolfinx_adjoint.Function(Q)
@@ -100,7 +100,7 @@ def solve_heat(ctrls):
 
 u, d, j = solve_heat(ctrls)
 
-alpha = dolfinx.fem.Constant(mesh, 1.0e-1)
+alpha = dolfinx.fem.Constant(mesh, np.float64(1.0e-1))
 regularisation = (
     alpha
     / 2

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -18,7 +18,7 @@ x = ufl.SpatialCoordinate(mesh)
 nu = dolfinx.fem.Constant(mesh, np.float64(1e-5))
 nu.name = "nu"  # type: ignore
 
-t = dolfinx_adjoint.Constant(mesh, dolfinx.default_scalar_type(0.0))
+t = dolfinx_adjoint.Constant(mesh, dolfinx.default_scalar_type(0.0))  # type: ignore
 t.name = "time"
 d = 16 * x[0] * (x[0] - 1) * x[1] * (x[1] - 1) * ufl.sin(ufl.pi * t)
 

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -22,7 +22,7 @@ t = dolfinx_adjoint.Function(Q)
 t.name = "time"
 d = 16 * x[0] * (x[0] - 1) * x[1] * (x[1] - 1) * ufl.sin(ufl.pi * t)
 
-dt = dolfinx.fem.Constant(mesh, dolfinx.default_scalar_type(0.1))
+dt = dolfinx.fem.Constant(mesh, dolfinx.default_scalar_type(0.1))  # type: ignore
 T = 1
 
 V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))  # type: ignore[arg-type]

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -14,11 +14,11 @@ import dolfinx_adjoint
 
 mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
 x = ufl.SpatialCoordinate(mesh)
-# FIXME: Until constant is taped we need to use Function
+
 nu = dolfinx.fem.Constant(mesh, np.float64(1e-5))
 nu.name = "nu"  # type: ignore
-Q = dolfinx.fem.functionspace(mesh, ("DG", 0))  # type: ignore[arg-type]
-t = dolfinx_adjoint.Function(Q)
+
+t = dolfinx_adjoint.Constant(mesh, dolfinx.default_scalar_type(0.0))
 t.name = "time"
 d = 16 * x[0] * (x[0] - 1) * x[1] * (x[1] - 1) * ufl.sin(ufl.pi * t)
 

--- a/demos/time_distributed_control.py
+++ b/demos/time_distributed_control.py
@@ -121,7 +121,7 @@ opt_ctrls = pyadjoint.minimize(
     rf,
     method="BFGS",
     # method="Newton-CG",
-    options={"maxiter": 50, "disp": True},
+    options={"maxiter": 100, "disp": True},
 )
 
 out_ctrl = dolfinx.fem.Function(V, name="optimal_control")
@@ -130,5 +130,6 @@ with dolfinx.io.VTXWriter(mesh.comm, "opt_ctrl.bp", [out_ctrl]) as vtx:
         out_ctrl.x.array[:] = c.x.array[:]
         vtx.write(t_val)
 
-assert np.isclose(np.linalg.norm(opt_ctrls[0].x.array), 4.925369634)
-assert np.isclose(np.linalg.norm(opt_ctrls[-1].x.array), 2.871728934)
+
+assert np.isclose(np.linalg.norm(opt_ctrls[0].x.array), 4.930056079391683)
+assert np.isclose(np.linalg.norm(opt_ctrls[-1].x.array), 2.8756312728703963)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 dev = ["pdbpp", "ipython", "mypy", "ruff"]
-docs = ["jupyter-book", "jupytext", "moola@git+https://github.com/funsim/moola.git","pandas", "pyvista[all]", "networkx"]
+docs = ["jupyter-book", "jupytext", "moola@git+https://github.com/funsim/moola.git","pandas", "pyvista[all]", "networkx", "pygraphviz"]
 all = ["dolfinx_adjoint[test]", "dolfinx_adjoint[dev]", "dolfinx_adjoint[docs]"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 dev = ["pdbpp", "ipython", "mypy", "ruff"]
-docs = ["jupyter-book", "jupytext", "moola@git+https://github.com/funsim/moola.git","pandas", "pyvista[all]"]
+docs = ["jupyter-book", "jupytext", "moola@git+https://github.com/funsim/moola.git","pandas", "pyvista[all]", "networkx"]
 all = ["dolfinx_adjoint[test]", "dolfinx_adjoint[dev]", "dolfinx_adjoint[docs]"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
       "fenics-dolfinx>=0.10.0",
       "pyadjoint-ad>=2025.10.0",
       "typing_extensions; python_version < '3.11'",
-      "scifem",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
       "fenics-dolfinx>=0.10.0",
       "pyadjoint-ad>=2025.10.0",
       "typing_extensions; python_version < '3.11'",
+      "scifem",
 ]
 
 

--- a/src/dolfinx_adjoint/__init__.py
+++ b/src/dolfinx_adjoint/__init__.py
@@ -7,7 +7,7 @@ import pyadjoint as _pyad
 
 from .assembly import assemble_scalar, error_norm
 from .solvers import LinearProblem, NonlinearProblem
-from .types import Function
+from .types import Constant, Function
 from .types.function import assign
 
 meta = metadata("dolfinx_adjoint")
@@ -22,6 +22,7 @@ _pyad.set_working_tape(_pyad.Tape())
 _pyad.continue_annotation()
 
 __all__ = [
+    "Constant",
     "Function",
     "LinearProblem",
     "NonlinearProblem",

--- a/src/dolfinx_adjoint/blocks/_vector.py
+++ b/src/dolfinx_adjoint/blocks/_vector.py
@@ -1,0 +1,77 @@
+import dolfinx
+import numpy as np
+import numpy.typing as npt
+
+
+class _SpecialVector(dolfinx.la.Vector):
+    """Workaround adding __iadd__ to `dolfinx.la.Vector`."""
+
+    def __init__(self, x, function_space: dolfinx.fem.FunctionSpace):
+        super().__init__(x)
+        self._function_space = function_space
+
+    def __iadd__(self, other):
+        self.array[:] += other.array[:]
+        return self
+
+    @property
+    def function_space(self) -> dolfinx.fem.FunctionSpace:
+        return self._function_space
+
+    @property
+    def x(self):
+        return self
+
+    @property
+    def name(self):
+        return "SpecialVector"
+
+
+def _vector(
+    map, bs: int, function_space: dolfinx.fem.FunctionSpace, dtype: npt.DTypeLike = np.float64
+) -> _SpecialVector:
+    """Create a distributed vector.
+
+    Args:
+        map: Index map the describes the size and distribution of the
+            vector.
+        bs: Block size.
+        dtype: The scalar type.
+
+    Returns:
+        A distributed vector.
+    """
+    if np.issubdtype(dtype, np.float32):
+        vtype = dolfinx.cpp.la.Vector_float32
+    elif np.issubdtype(dtype, np.float64):
+        vtype = dolfinx.cpp.la.Vector_float64
+    elif np.issubdtype(dtype, np.complex64):
+        vtype = dolfinx.cpp.la.Vector_complex64
+    elif np.issubdtype(dtype, np.complex128):
+        vtype = dolfinx.cpp.la.Vector_complex128
+    elif np.issubdtype(dtype, np.int8):
+        vtype = dolfinx.cpp.la.Vector_int8
+    elif np.issubdtype(dtype, np.int32):
+        vtype = dolfinx.cpp.la.Vector_int32
+    elif np.issubdtype(dtype, np.int64):
+        vtype = dolfinx.cpp.la.Vector_int64
+    else:
+        raise NotImplementedError(f"Type {dtype} not supported.")
+
+    return _SpecialVector(vtype(map, bs), function_space)
+
+
+def _create_vector(L: dolfinx.fem.Form, space: dolfinx.fem.FunctionSpace) -> _SpecialVector:
+    """Create a Vector that is compatible with a given linear form.
+
+    Args:
+        L: A linear form.
+
+    Returns:
+        A vector that the form can be assembled into.
+    """
+    # Can just take the first dofmap here, since all dof maps have the same
+    # index map in mixed-topology meshes
+    dofmap = L.function_spaces[0].dofmaps(0)  # type: ignore
+    assert space._cpp_object == L.function_spaces[0], "Function space mismatch when creating vector."
+    return _vector(dofmap.index_map, dofmap.index_map_bs, dtype=L.dtype, function_space=space)

--- a/src/dolfinx_adjoint/blocks/assembly.py
+++ b/src/dolfinx_adjoint/blocks/assembly.py
@@ -3,85 +3,11 @@ import typing
 from mpi4py import MPI
 
 import dolfinx
-import numpy as np
-import numpy.typing as npt
 import ufl
 from pyadjoint import Block, create_overloaded_object
 from ufl.formatting.ufl2unicode import ufl2unicode
 
-
-class _SpecialVector(dolfinx.la.Vector):
-    """Workaround adding __iadd__ to `dolfinx.la.Vector`."""
-
-    def __init__(self, x, function_space: dolfinx.fem.FunctionSpace):
-        super().__init__(x)
-        self._function_space = function_space
-
-    def __iadd__(self, other):
-        self.array[:] += other.array[:]
-        return self
-
-    @property
-    def function_space(self) -> dolfinx.fem.FunctionSpace:
-        return self._function_space
-
-    @property
-    def x(self):
-        return self
-
-    @property
-    def name(self):
-        return "SpecialVector"
-
-
-def _vector(
-    map, bs: int, function_space: dolfinx.fem.FunctionSpace, dtype: npt.DTypeLike = np.float64
-) -> _SpecialVector:
-    """Create a distributed vector.
-
-    Args:
-        map: Index map the describes the size and distribution of the
-            vector.
-        bs: Block size.
-        dtype: The scalar type.
-
-    Returns:
-        A distributed vector.
-    """
-    if np.issubdtype(dtype, np.float32):
-        vtype = dolfinx.cpp.la.Vector_float32
-    elif np.issubdtype(dtype, np.float64):
-        vtype = dolfinx.cpp.la.Vector_float64
-    elif np.issubdtype(dtype, np.complex64):
-        vtype = dolfinx.cpp.la.Vector_complex64
-    elif np.issubdtype(dtype, np.complex128):
-        vtype = dolfinx.cpp.la.Vector_complex128
-    elif np.issubdtype(dtype, np.int8):
-        vtype = dolfinx.cpp.la.Vector_int8
-    elif np.issubdtype(dtype, np.int32):
-        vtype = dolfinx.cpp.la.Vector_int32
-    elif np.issubdtype(dtype, np.int64):
-        vtype = dolfinx.cpp.la.Vector_int64
-    else:
-        raise NotImplementedError(f"Type {dtype} not supported.")
-
-    return _SpecialVector(vtype(map, bs), function_space)
-
-
-def _create_vector(L: dolfinx.fem.Form, space: dolfinx.fem.FunctionSpace) -> _SpecialVector:
-    """Create a Vector that is compatible with a given linear form.
-
-    Args:
-        L: A linear form.
-
-    Returns:
-        A vector that the form can be assembled into.
-    """
-    # Can just take the first dofmap here, since all dof maps have the same
-    # index map in mixed-topology meshes
-    dofmap = L.function_spaces[0].dofmaps(0)  # type: ignore
-    assert space._cpp_object == L.function_spaces[0], "Function space mismatch when creating vector."
-    return _vector(dofmap.index_map, dofmap.index_map_bs, dtype=L.dtype, function_space=space)
+from ._vector import _create_vector, _SpecialVector
 
 
 def assemble_compiled_form(

--- a/src/dolfinx_adjoint/blocks/assembly.py
+++ b/src/dolfinx_adjoint/blocks/assembly.py
@@ -7,7 +7,7 @@ import ufl
 from pyadjoint import Block, create_overloaded_object
 from ufl.formatting.ufl2unicode import ufl2unicode
 
-from ._vector import _create_vector, _SpecialVector
+from ._vector import _create_vector, _SpecialVector, _vector  # noqa: F401
 
 
 def assemble_compiled_form(

--- a/src/dolfinx_adjoint/blocks/function_assigner.py
+++ b/src/dolfinx_adjoint/blocks/function_assigner.py
@@ -8,6 +8,8 @@ from ufl.formatting.ufl2unicode import ufl2unicode
 
 from dolfinx_adjoint.utils import function_from_vector
 
+from ._vector import _vector
+
 
 class FunctionAssignBlock(Block):
     def __init__(
@@ -70,10 +72,13 @@ class FunctionAssignBlock(Block):
                         # Catch the case where adj_inputs[0] is just a float
                         return adj_inputs[0]
             elif isinstance(func := block_variable.output, dolfinx.fem.Function):
-                adj_output = dolfinx.fem.Function(func.function_space)
                 assert func.function_space == prepared.function_space
-                adj_output.x.array[:] = prepared.x.array[:]
-                return adj_output.x
+                vec = _vector(
+                    prepared.x.index_map, prepared.x.block_size, func.function_space, dtype=prepared.x.array.dtype
+                )
+                vec.array[:] = prepared.x.array[:]
+                return vec
+
             else:
                 raise NotImplementedError(f"Adjoint for {block_variable=} not implemented.")
             # elif isinstance(block_variable.output, dolfinx.fem.Constant):

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -555,8 +555,10 @@ class LinearProblemBlock(pyadjoint.Block):
             if tlm_input is None:
                 continue
 
-            if c2 == self._u and not self.linear:
-                continue
+            # If problem is non-linear we need to skip the output variable as a control, as we can't differentiate with
+            # respect to the initial guess
+            # if c2 == self._u and not self.linear:
+            #     continue
 
             # TODO: If tlm_input is a Sum, this crashes in some instances?
             if isinstance(c2_rep, dolfinx.mesh.Mesh):

--- a/src/dolfinx_adjoint/types/__init__.py
+++ b/src/dolfinx_adjoint/types/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["Function"]
+__all__ = ["Function", "Constant"]
 
-from .function import Function
+from .function import Constant, Function

--- a/src/dolfinx_adjoint/types/function.py
+++ b/src/dolfinx_adjoint/types/function.py
@@ -209,7 +209,7 @@ class Function(dolfinx.fem.Function, FloatingType):
 
 
 class Constant(Function):
-    """A class overloading `dolfinx.fem.Constant`
+    """A class overloading {py:class}`dolfinx.fem.Constant`
     to support it being used as a control variable in
     the adjoint framework.
 
@@ -218,14 +218,14 @@ class Constant(Function):
         c: The value of the constant. Can be a scalar, a sequence, or a numpy array.
 
     Note:
-        The `Constant` class is implemented as a subclass of `Function` to leverage the
+        The {py:class}`Constant` class is implemented as a subclass of {py:class}`Function` to leverage the
         existing functionality for handling function spaces and vectors. The value of
         the constant is stored in the underlying vector of the function, and the class
         provides a property to access this value conveniently.
 
-        If :code:`basix.ufl.real_element` is not available, the class will attempt to use
-        :code:`scifem` to create a function space for the constant (which would then require
-        :code:`scifem` to be installed - :code:`pip install scifem`).
+        If {py:func}`basix.ufl.real_element` is not available, the class will attempt to use
+        {py:mod}`scifem` to create a function space for the constant (which would then require
+        {py:mod}`scifem` to be installed - :code:`pip install scifem`).
 
     """
 

--- a/src/dolfinx_adjoint/types/function.py
+++ b/src/dolfinx_adjoint/types/function.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # for Python<3.11
 
+import basix.ufl
 import dolfinx
 import numpy
 import ufl
@@ -207,15 +208,43 @@ class Function(dolfinx.fem.Function, FloatingType):
 
 
 class Constant(Function):
+    """A class overloading `dolfinx.fem.Constant`
+    to support it being used as a control variable in
+    the adjoint framework.
+
+    Args:
+        domain: The mesh on which the constant is defined.
+        c: The value of the constant. Can be a scalar, a sequence, or a numpy array.
+
+    Note:
+        The `Constant` class is implemented as a subclass of `Function` to leverage the
+        existing functionality for handling function spaces and vectors. The value of
+        the constant is stored in the underlying vector of the function, and the class
+        provides a property to access this value conveniently.
+
+        If :code:`basix.ufl.real_element` is not available, the class will attempt to use
+        :code:`scifem` to create a function space for the constant (which would then require
+        :code:`scifem` to be installed - :code:`pip install scifem`).
+
+    """
+
     def __init__(
         self,
         domain: dolfinx.mesh.Mesh,
         c: float | numpy.floating | complex | numpy.complexfloating | typing.Sequence | numpy.ndarray,
     ):
-        import scifem
-
         value_shape = numpy.shape(c)
-        V = scifem.create_real_functionspace(domain, value_shape=value_shape)
+        try:
+            el = basix.ufl.real_element(domain.basix_cell(), value_shape=numpy.shape(c))
+            V = dolfinx.fem.functionspace(domain, el)
+
+        except AttributeError:
+            try:
+                import scifem
+            except ImportError as e:
+                raise ImportError("scifem is required to use Constant 'pip install scifem") from e
+
+            V = scifem.create_real_functionspace(domain, value_shape=value_shape)
         super().__init__(V)
         self.x.array[:] = c
 

--- a/src/dolfinx_adjoint/types/function.py
+++ b/src/dolfinx_adjoint/types/function.py
@@ -41,7 +41,7 @@ class Function(dolfinx.fem.Function, FloatingType):
         V: dolfinx.fem.FunctionSpace,
         x: typing.Optional[dolfinx.la.Vector] = None,
         name: typing.Optional[str] = None,
-        dtype: numpy.dtype = dolfinx.default_scalar_type,
+        dtype: numpy.dtype = dolfinx.default_scalar_type,  # type: ignore[assignment]
         **kwargs,
     ):
         super(Function, self).__init__(

--- a/src/dolfinx_adjoint/types/function.py
+++ b/src/dolfinx_adjoint/types/function.py
@@ -254,6 +254,7 @@ class Constant(Function):
 
 
 register_overloaded_type(Function, (dolfinx.fem.Function, Function))
+register_overloaded_type(Constant, (dolfinx.fem.Constant, Constant))
 
 
 def assign(value: typing.Union[numpy.inexact, float, int], function: Function, **kwargs: typing.Unpack[ad_kwargs]):

--- a/src/dolfinx_adjoint/types/function.py
+++ b/src/dolfinx_adjoint/types/function.py
@@ -206,6 +206,24 @@ class Function(dolfinx.fem.Function, FloatingType):
         return dst, offset
 
 
+class Constant(Function):
+    def __init__(
+        self,
+        domain: dolfinx.mesh.Mesh,
+        c: float | numpy.floating | complex | numpy.complexfloating | typing.Sequence | numpy.ndarray,
+    ):
+        import scifem
+
+        value_shape = numpy.shape(c)
+        V = scifem.create_real_functionspace(domain, value_shape=value_shape)
+        super().__init__(V)
+        self.x.array[:] = c
+
+    @property
+    def value(self):
+        return self.x.array[:]
+
+
 register_overloaded_type(Function, (dolfinx.fem.Function, Function))
 
 

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -27,6 +27,54 @@ def mesh_3D():
     return dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 50, 50, 50)
 
 
+def test_multiple_assign_adjoint_accumulation(mesh_1D):
+    """
+    Test that assigning a Function multiple times and computing the adjoint
+    successfully accumulates the adjoints. This tests the IAddableVector patch.
+    """
+    pyadjoint.get_working_tape().clear_tape()
+    mesh = mesh_1D
+
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+
+    # 1. Create a control function
+    f = Function(V, name="f_control")
+    f.interpolate(lambda x: 2.0 * x[0])
+
+    # 2. Fork the computational graph by assigning f to two different functions
+    u1 = Function(V, name="u1")
+    assign(f, u1)
+
+    u2 = Function(V, name="u2")
+    assign(f, u2)
+
+    # 3. Assemble a functional depending on both branches
+    J_form = (u1**2 + u2**2) * ufl.dx(domain=mesh)
+    J = assemble_scalar(J_form)
+
+    control = pyadjoint.Control(f)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    # 4. Compute the derivative
+    # Before the patch, this would crash because pyadjoint attempts to sum
+    # the adjoint contributions from u1 and u2 using `+=` on dolfinx.la.Vector.
+    # After the patch, IAddableVector handles this gracefully.
+    grad = Jhat.derivative()
+    assert grad is not None
+
+    # 5. Verify the math with a Taylor test
+    df = Function(V)
+    df.interpolate(lambda x: np.sin(x[0]))
+
+    # Without gradient
+    min_rate_0 = pyadjoint.taylor_test(Jhat, f, df, dJdm=0)
+    assert np.isclose(min_rate_0, 1.0, rtol=1e-2, atol=1e-2)
+
+    # With gradient
+    min_rate_1 = pyadjoint.taylor_test(Jhat, f, df)
+    assert np.isclose(min_rate_1, 2.0, rtol=1e-2, atol=1e-2)
+
+
 @pytest.mark.parametrize("constant", [np.float64(0.2), float(-0.13), int(3)])
 @pytest.mark.parametrize("mesh_var_name", ["mesh_1D", "mesh_2D", "mesh_3D"])
 def test_assign_constant(mesh_var_name: str, request, constant: typing.Union[float, int, np.floating]):

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -9,7 +9,7 @@ import pyadjoint
 import pytest
 import ufl
 
-from dolfinx_adjoint import Function, assemble_scalar, assign
+from dolfinx_adjoint import Constant, Function, assemble_scalar, assign
 
 
 @pytest.fixture(scope="module")
@@ -126,3 +126,36 @@ def test_assign_constant(mesh_var_name: str, request, constant: typing.Union[flo
         options={"maxiter": 200, "disp": True},
     )
     np.testing.assert_allclose(float(opt), float(c), atol=1e-5)
+
+
+def test_assign_constant_derivative():
+    pyadjoint.get_working_tape().clear_tape()
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+
+    # Target constant
+    c = Constant(mesh, dolfinx.default_scalar_type(0.5))
+
+    # Control variable
+    d = pyadjoint.AdjFloat(0.2)
+
+    # Tape the assignment
+    assign(d, c)
+
+    # Assemble a functional: J = c^2 * dx
+    J_form = c**2 * ufl.dx(domain=mesh)
+    J = assemble_scalar(J_form)
+
+    control = pyadjoint.Control(d)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    # Forward check: J(0.2) = 0.2^2 * 1.0 = 0.04
+    assert np.isclose(Jhat(d), 0.04)
+
+    # Gradient check: dJ/dd = 2*d * 1.0 = 2(0.2) = 0.4
+    dJ = Jhat.derivative()
+    assert np.isclose(dJ, 0.4)
+
+    # Taylor test validation
+    dd = pyadjoint.AdjFloat(0.1)
+    min_rate = pyadjoint.taylor_test(Jhat, d, dd)
+    assert np.isclose(min_rate, 2.0, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
Based on: https://dolfin-adjoint.github.io/dolfin-adjoint/documentation/time-distributed-control/time-distributed-control.html

Gives exact same iteration count in LBFGS and NewtonCG if one changes `d` to spatial coordinate in original example.

- [x] Constant as overloaded type