### PR TITLE
Update linear problem after dolfinx api change

### DIFF
--- a/demos/poisson_mother.py
+++ b/demos/poisson_mother.py
@@ -113,7 +113,10 @@ grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(refined_mesh))
 plotter = pyvista.Plotter()
 plotter.add_mesh(grid, show_edges=True, color="lightgrey")
 plotter.view_xy()
-plotter.show()
+if pyvista.OFF_SCREEN:
+    plotter.screenshot("poisson_mother_mesh.png")
+else:
+    plotter.show()
 # -
 
 # Then we define the discrete function spaces $V$ and $Q$ for the state and control variable, respectively
@@ -200,8 +203,8 @@ J_symbolic = 0.5 * ufl.inner(uh - d, uh - d) * ufl.dx + 0.5 * alpha * ufl.inner(
 J = dolfinx_adjoint.assemble_scalar(J_symbolic)
 
 # The next step is to formulate the so-called reduced optimization problem.
-# The idea is that the solution $u$ cna be considered as a functin of $f$:
-# given a value of $f$, we can solve the Poisson equation and obtain the associated solution $uh$.
+# The idea is that the solution $u$ can be considered as a functin of $f$:
+# given a value of $f$, we can solve the Poisson equation and obtain the associated solution $u_h$.
 # Bu denoting this solution function as $u(f)$ we can rewrite the original optimization problem as a reduced problem:
 
 # $$
@@ -306,7 +309,10 @@ warped_f_ex = plotting_grid.warp_by_scalar("f_exact", factor=scale_factor)
 plotter.add_mesh(warped_f_ex, scalars="f_exact", show_edges=True)
 plotter.link_views((0, 1))
 plotter.link_views((2, 3))
-plotter.show()
+if pyvista.OFF_SCREEN:
+    plotter.screenshot("poisson_mother.png")
+else:
+    plotter.show()
 # -
 
 # ## Convergence analysis (mesh independence)
@@ -424,7 +430,8 @@ results_bfgs = []
 for N in [16, 32, 64, 128]:
     results_bfgs.append(solve_optimal_problem(N, use_newton=False))
 
-pandas.DataFrame(results_bfgs)
+bfgs_results = pandas.DataFrame(results_bfgs)
+bfgs_results
 
 # We observe that the number of iterations is independent of the mesh resolution, and that the errors in the
 # state and control goes down with a rate of 1.

--- a/demos/poisson_mother.py
+++ b/demos/poisson_mother.py
@@ -112,7 +112,7 @@ del mesh
 grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(refined_mesh))
 plotter = pyvista.Plotter()
 plotter.add_mesh(grid, show_edges=True, color="lightgrey")
-plotter.view_xy()
+plotter.view_xy(plotter)
 if pyvista.OFF_SCREEN:
     plotter.screenshot("poisson_mother_mesh.png")
 else:

--- a/src/dolfinx_adjoint/blocks/assembly.py
+++ b/src/dolfinx_adjoint/blocks/assembly.py
@@ -113,7 +113,7 @@ class AssembleBlock(Block):
         ad_block_tag: typing.Optional[str] = None,
         jit_options: typing.Optional[dict] = None,
         form_compiler_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]]] = None,
+        entity_maps: typing.Optional[typing.Sequence[dolfinx.mesh.EntityMap]] = None,
     ):
         super(AssembleBlock, self).__init__(ad_block_tag=ad_block_tag)
 

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -20,22 +20,22 @@ class LinearProblemBlock(pyadjoint.Block):
     This class extends the `dolfinx.fem.petsc.LinearProblem` to support adjoint methods.
     """
 
-    _adjoint_solutions: typing.Union[Function, typing.Iterable[Function]]
-    _second_adjoint_solutions: typing.Union[Function, typing.Iterable[Function]]
+    _adjoint_solutions: typing.Union[Function, typing.Sequence[Function]]
+    _second_adjoint_solutions: typing.Union[Function, typing.Sequence[Function]]
 
     def __init__(
         self,
-        a: typing.Union[ufl.Form, typing.Iterable[typing.Iterable[ufl.Form]]],
-        L: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
-        bcs: typing.Optional[typing.Iterable[dolfinx.fem.DirichletBC]] = None,
-        u: typing.Optional[typing.Union[dolfinx.fem.Function, typing.Iterable[dolfinx.fem.Function]]] = None,
-        P: typing.Optional[typing.Union[ufl.Form, typing.Iterable[typing.Iterable[ufl.Form]]]] = None,
-        kind: typing.Optional[typing.Union[str, typing.Iterable[typing.Iterable[str]]]] = None,
+        a: typing.Union[ufl.Form, typing.Sequence[typing.Sequence[ufl.Form]]],
+        L: typing.Union[ufl.Form, typing.Sequence[ufl.Form]],
+        bcs: typing.Optional[typing.Sequence[dolfinx.fem.DirichletBC]] = None,
+        u: typing.Optional[typing.Union[dolfinx.fem.Function, typing.Sequence[dolfinx.fem.Function]]] = None,
+        P: typing.Optional[typing.Union[ufl.Form, typing.Sequence[typing.Sequence[ufl.Form]]]] = None,
+        kind: typing.Optional[typing.Union[str, typing.Sequence[typing.Sequence[str]]]] = None,
         petsc_options: typing.Optional[dict] = None,
         petsc_options_prefix: str = "dxa_linear_problem_block_",
         form_compiler_options: typing.Optional[dict] = None,
         jit_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]]] = None,
+        entity_maps: typing.Optional[typing.Sequence[dolfinx.mesh.EntityMap]] = None,
         ad_block_tag: typing.Optional[str] = None,
         adjoint_petsc_options: typing.Optional[dict] = None,
         tlm_petsc_options: typing.Optional[dict] = None,
@@ -106,8 +106,8 @@ class LinearProblemBlock(pyadjoint.Block):
         self._kind = "nest" if self._forward_solver.A.getType() == "nest" else kind
 
         if isinstance(self._u, dolfinx.fem.Function):
-            self._adjoint_solutions = self._u.copy()
-            self._second_adjoint_solutions = self._u.copy()
+            self._adjoint_solutions = self._u.copy()  # type: ignore[assignment]
+            self._second_adjoint_solutions = self._u.copy()  # type: ignore[assignment]
         else:
             assert isinstance(self._u, typing.Iterable)
             self._adjoint_solutions = [u.copy() for u in self._u]
@@ -231,8 +231,8 @@ class LinearProblemBlock(pyadjoint.Block):
 
     @classmethod
     def _compute_adjoint(
-        cls, form: typing.Union[ufl.Form, typing.Iterable[typing.Iterable[ufl.Form]]]
-    ) -> typing.Union[ufl.Form, typing.Sequence[typing.Iterable[ufl.Form]]]:
+        cls, form: typing.Union[ufl.Form, typing.Sequence[typing.Sequence[ufl.Form]]]
+    ) -> typing.Union[ufl.Form, typing.Sequence[typing.Sequence[ufl.Form]]]:
         """
         Compute adjoint of a bilinear form :math:`a(u, v)`, which could be written as a blocked system.
         """

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -3,8 +3,6 @@ import typing
 from petsc4py import PETSc
 
 import dolfinx.fem.petsc
-import numpy as np
-import numpy.typing as npt
 import pyadjoint
 import ufl
 

--- a/src/dolfinx_adjoint/petsc_utils.py
+++ b/src/dolfinx_adjoint/petsc_utils.py
@@ -60,7 +60,7 @@ class LinearAdjointProblem(dolfinx.fem.petsc.LinearProblem):
 
     def solve(
         self,
-    ) -> typing.Tuple[typing.Union[dolfinx.fem.Function, typing.Iterable[dolfinx.fem.Function]], int, int]:
+    ) -> typing.Union[dolfinx.fem.Function, typing.Sequence[dolfinx.fem.Function]]:
         """Solve the problem."""
 
         # Assemble lhs
@@ -86,6 +86,4 @@ class LinearAdjointProblem(dolfinx.fem.petsc.LinearProblem):
         self._solver.solve(self._b, self._x)
         dolfinx.la.petsc._ghost_update(self._x, PETSc.InsertMode.INSERT, PETSc.ScatterMode.FORWARD)  # type: ignore
         dolfinx.fem.petsc.assign(self._x, self._u)
-        converged_reason = self._solver.getConvergedReason()
-        num_iterations = self._solver.getIterationNumber()
-        return self._u, converged_reason, num_iterations
+        return self._u

--- a/src/dolfinx_adjoint/solvers.py
+++ b/src/dolfinx_adjoint/solvers.py
@@ -38,17 +38,17 @@ class LinearProblem(dolfinx.fem.petsc.LinearProblem):
 
     def __init__(
         self,
-        a: typing.Union[ufl.Form, typing.Iterable[typing.Iterable[ufl.Form]]],
-        L: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
-        bcs: typing.Optional[typing.Iterable[dolfinx.fem.DirichletBC]] = None,
-        u: typing.Optional[typing.Union[dolfinx.fem.Function, typing.Iterable[dolfinx.fem.Function]]] = None,
-        P: typing.Optional[typing.Union[ufl.Form, typing.Iterable[typing.Iterable[ufl.Form]]]] = None,
-        kind: typing.Optional[typing.Union[str, typing.Iterable[typing.Iterable[str]]]] = None,
+        a: typing.Union[ufl.Form, typing.Sequence[typing.Sequence[ufl.Form]]],
+        L: typing.Union[ufl.Form, typing.Sequence[ufl.Form]],
+        bcs: typing.Optional[typing.Sequence[dolfinx.fem.DirichletBC]] = None,
+        u: typing.Optional[typing.Union[dolfinx.fem.Function, typing.Sequence[dolfinx.fem.Function]]] = None,
+        P: typing.Optional[typing.Union[ufl.Form, typing.Sequence[typing.Sequence[ufl.Form]]]] = None,
+        kind: typing.Optional[typing.Union[str, typing.Sequence[typing.Sequence[str]]]] = None,
         petsc_options: typing.Optional[dict] = None,
         petsc_options_prefix: str = "dxa_linear_problem_",
         form_compiler_options: typing.Optional[dict] = None,
         jit_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]]] = None,
+        entity_maps: typing.Optional[typing.Sequence[dolfinx.mesh.EntityMap]] = None,
         ad_block_tag: typing.Optional[str] = None,
         adjoint_petsc_options: typing.Optional[dict] = None,
         tlm_petsc_options: typing.Optional[dict] = None,
@@ -96,9 +96,7 @@ class LinearProblem(dolfinx.fem.petsc.LinearProblem):
             entity_maps=entity_maps,
         )
 
-    def solve(
-        self, annotate: bool = True
-    ) -> typing.Tuple[typing.Union[dolfinx.fem.Function, typing.Iterable[dolfinx.fem.Function]], int, int]:
+    def solve(self, annotate: bool = True) -> typing.Union[dolfinx.fem.Function, typing.Sequence[dolfinx.fem.Function]]:
         """
         Solve the linear problem and return the solution.
         """

--- a/src/dolfinx_adjoint/solvers.py
+++ b/src/dolfinx_adjoint/solvers.py
@@ -4,8 +4,6 @@ except ModuleNotFoundError:
     import typing  # type: ignore[no-redef]
 
 import dolfinx.fem.petsc
-import numpy as np
-import numpy.typing as npt
 import pyadjoint
 import ufl
 

--- a/tests/test_poisson_mother.py
+++ b/tests/test_poisson_mother.py
@@ -80,19 +80,25 @@ def reference_solution(
         "pc_factor_mat_solver_type": "mumps",
         "ksp_error_if_not_converged": True,
     }
-    forward_problem = dolfinx.fem.petsc.LinearProblem(a, L, u=uh, petsc_options=petsc_options, bcs=[bc])
+    forward_problem = dolfinx.fem.petsc.LinearProblem(
+        a, L, u=uh, petsc_options=petsc_options, petsc_options_prefix="forward_problem_", bcs=[bc]
+    )
     forward_problem.solve()
 
     # Solve TLM
     a_tlm = dFdu
     L_tlm = -ufl.action(dFdm, dm)
-    problem_tlm = dolfinx.fem.petsc.LinearProblem(a_tlm, L_tlm, u=u_dot, petsc_options=petsc_options, bcs=[bc])
+    problem_tlm = dolfinx.fem.petsc.LinearProblem(
+        a_tlm, L_tlm, u=u_dot, petsc_options=petsc_options, petsc_options_prefix="tlm_problem_", bcs=[bc]
+    )
     problem_tlm.solve()
 
     # Solve adjoint problem
     a_adj = ufl.adjoint(dFdu)
     L_adj = dJdu
-    problem_adj = dolfinx.fem.petsc.LinearProblem(a_adj, L_adj, u=lmbda, petsc_options=petsc_options, bcs=[bc])
+    problem_adj = dolfinx.fem.petsc.LinearProblem(
+        a_adj, L_adj, u=lmbda, petsc_options=petsc_options, petsc_options_prefix="adjoint_problem_", bcs=[bc]
+    )
     problem_adj.solve()
 
     # Solve second order adjoint problem
@@ -102,7 +108,9 @@ def reference_solution(
     # + ufl.action(ufl.adjoint(d2Jdmdu), dm)
     # - ufl.action(ufl.action(ufl.adjoint(d2Fdudu), u_dot), lmbda)
     # - ufl.action(ufl.adjoint(ufl.action(d2Fdmdm,dm)),lmbda)
-    problem_soa = dolfinx.fem.petsc.LinearProblem(a_soa, L_soa, u=lmbda_dot, petsc_options=petsc_options, bcs=[bc])
+    problem_soa = dolfinx.fem.petsc.LinearProblem(
+        a_soa, L_soa, u=lmbda_dot, petsc_options=petsc_options, petsc_options_prefix="soa_problem_", bcs=[bc]
+    )
     problem_soa.solve()
 
     # [delta m]^T  d^2 J / dm^2 [delta m]


### PR DESCRIPTION
Add mandatory `petsc_options_prefix` which was introduced in see https://github.com/FEniCS/dolfinx/pull/3785.
Calling solve now on LinearProblem seem to only return the solution (see https://github.com/FEniCS/dolfinx/pull/3810).
I also added an option to save pyvista screenshots in the demo in running OFF_SCREEN. 