### PR TITLE
Use `_create_vector` when assembling compiled form

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ parse:
 sphinx:
   config:
     html_last_updated_fmt: "%b %d, %Y"
+    nb_execution_show_tb: True
     nb_custom_formats:
       .py:
         - jupytext.reads

--- a/src/dolfinx_adjoint/blocks/assembly.py
+++ b/src/dolfinx_adjoint/blocks/assembly.py
@@ -81,7 +81,7 @@ def assemble_compiled_form(
     """
 
     if form.rank == 1:
-        tensor = dolfinx.fem.create_vector(form) if tensor is None else tensor
+        tensor = _create_vector(form) if tensor is None else tensor
         assert isinstance(tensor, dolfinx.la.Vector)
         dolfinx.fem.assemble._assemble_vector_array(tensor.array, form)
         tensor.scatter_reverse(dolfinx.la.InsertMode.add)


### PR DESCRIPTION
Also added traceback info in case the docs fails during build