### PR TITLE
Adding overload for DirichletBC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
       "fenics-dolfinx>=0.10.0",
       "pyadjoint-ad>=2025.10.0",
       "typing_extensions; python_version < '3.11'",
+      "packaging>=24.2",
 ]
 
 

--- a/src/dolfinx_adjoint/__init__.py
+++ b/src/dolfinx_adjoint/__init__.py
@@ -7,7 +7,7 @@ import pyadjoint as _pyad
 
 from .assembly import assemble_scalar, error_norm
 from .solvers import LinearProblem, NonlinearProblem
-from .types import Constant, Function
+from .types import Constant, Function, dirichletbc
 from .types.function import assign
 
 meta = metadata("dolfinx_adjoint")
@@ -24,6 +24,7 @@ _pyad.continue_annotation()
 __all__ = [
     "Constant",
     "Function",
+    "dirichletbc",
     "LinearProblem",
     "NonlinearProblem",
     "assemble_scalar",

--- a/src/dolfinx_adjoint/blocks/assembly.py
+++ b/src/dolfinx_adjoint/blocks/assembly.py
@@ -129,6 +129,7 @@ class AssembleBlock(Block):
                 form_compiler_options=self._form_compiler_options,
                 entity_maps=self._entity_maps,
             )
+
             if space is None:
                 # If space is not supplied infer it from the form
                 assert len(dform.arguments()) == 1
@@ -143,6 +144,9 @@ class AssembleBlock(Block):
             # assemble_compiled_form(compiled_adjoint, self._cached_vectors[id(space)])
             assemble_compiled_form(compiled_adjoint, vector)
             # return a vector scaled by the scalar `adj_input`
+            # Safegaurd against None seeds from PyAdjoint
+            if adj_input is None:
+                adj_input = 1.0
             vector.array[:] *= vector.x.array.dtype.type(adj_input)
             vector.scatter_forward()
 

--- a/src/dolfinx_adjoint/blocks/dirichletbc.py
+++ b/src/dolfinx_adjoint/blocks/dirichletbc.py
@@ -5,6 +5,16 @@ from pyadjoint.block import Block
 
 
 class DirichletBCBlock(Block):
+    """A block representing a DirichletBC in the adjoint framework.
+
+    Args:
+        value: The value of the Dirichlet BC.
+        dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
+        V: The function space associated with the Dirichlet BC.
+        ad_block_tag: An optional tag to identify this block in the adjoint framework.
+
+    """
+
     def __init__(
         self,
         value: dolfinx.fem.Function | dolfinx.fem.Constant,
@@ -13,9 +23,17 @@ class DirichletBCBlock(Block):
         ad_block_tag=None,
     ):
         super().__init__(ad_block_tag=ad_block_tag)
-        self.dofs = dofs
-        self.V = V
+        self._dofs = dofs
+        self._V = V
         self.add_dependency(value)
+
+    @property
+    def dofs(self):
+        return self._dofs
+
+    @property
+    def V(self):
+        return self._V
 
     def prepare_recompute_component(self, inputs, relevant_outputs):
         return inputs[0] if inputs else None

--- a/src/dolfinx_adjoint/blocks/dirichletbc.py
+++ b/src/dolfinx_adjoint/blocks/dirichletbc.py
@@ -20,7 +20,7 @@ class DirichletBCBlock(Block):
         value: dolfinx.fem.Function | dolfinx.fem.Constant,
         dofs: npt.NDArray[np.int32],
         V: dolfinx.fem.FunctionSpace | None = None,
-        ad_block_tag=None,
+        ad_block_tag: str = None,
     ):
         super().__init__(ad_block_tag=ad_block_tag)
         self._dofs = dofs

--- a/src/dolfinx_adjoint/blocks/dirichletbc.py
+++ b/src/dolfinx_adjoint/blocks/dirichletbc.py
@@ -1,0 +1,40 @@
+import dolfinx
+from pyadjoint.block import Block
+from pyadjoint.tape import stop_annotating
+
+
+class DirichletBCBlock(Block):
+    def __init__(self, value, dofs, V=None, ad_block_tag=None):
+        super().__init__(ad_block_tag=ad_block_tag)
+        self.dofs = dofs
+        self.V = V
+
+        # Add dependency on the underlying overloaded Function or Constant
+        self.add_dependency(value)
+
+    def __str__(self):
+        return "dirichletbc"
+
+    def prepare_recompute_component(self, inputs, relevant_outputs):
+        # Extract the checkpointed `value` from the inputs
+        return inputs[0] if inputs else None
+
+    def recompute_component(self, inputs, block_variable, idx, prepared):
+        # Re-instantiate the FEniCSx boundary condition with the rewound tape value
+        with stop_annotating():
+            return dolfinx.fem.dirichletbc(prepared, self.dofs, self.V)
+
+    # Empty stubs required by the PyAdjoint Block interface for passive nodes
+    def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
+        pass
+
+    def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
+        pass
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
+        pass
+
+    def evaluate_hessian_component(
+        self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None
+    ):
+        pass

--- a/src/dolfinx_adjoint/blocks/dirichletbc.py
+++ b/src/dolfinx_adjoint/blocks/dirichletbc.py
@@ -20,7 +20,7 @@ class DirichletBCBlock(Block):
         value: dolfinx.fem.Function | dolfinx.fem.Constant,
         dofs: npt.NDArray[np.int32],
         V: dolfinx.fem.FunctionSpace | None = None,
-        ad_block_tag: str = None,
+        ad_block_tag: str | None = None,
     ):
         super().__init__(ad_block_tag=ad_block_tag)
         self._dofs = dofs

--- a/src/dolfinx_adjoint/blocks/dirichletbc.py
+++ b/src/dolfinx_adjoint/blocks/dirichletbc.py
@@ -1,6 +1,4 @@
-import dolfinx
 from pyadjoint.block import Block
-from pyadjoint.tape import stop_annotating
 
 
 class DirichletBCBlock(Block):
@@ -16,13 +14,12 @@ class DirichletBCBlock(Block):
         return "dirichletbc"
 
     def prepare_recompute_component(self, inputs, relevant_outputs):
-        # Extract the checkpointed `value` from the inputs
         return inputs[0] if inputs else None
 
     def recompute_component(self, inputs, block_variable, idx, prepared):
-        # Re-instantiate the FEniCSx boundary condition with the rewound tape value
-        with stop_annotating():
-            return dolfinx.fem.dirichletbc(prepared, self.dofs, self.V)
+        # PyAdjoint relies on checkpoints. The dynamic `_cpp_object` property
+        # in DirichletBC ensures FEniCSx handles the C++ updates internally.
+        return block_variable.saved_output
 
     # Empty stubs required by the PyAdjoint Block interface for passive nodes
     def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):

--- a/src/dolfinx_adjoint/blocks/dirichletbc.py
+++ b/src/dolfinx_adjoint/blocks/dirichletbc.py
@@ -1,37 +1,24 @@
+import dolfinx
+import numpy as np
+import numpy.typing as npt
 from pyadjoint.block import Block
 
 
 class DirichletBCBlock(Block):
-    def __init__(self, value, dofs, V=None, ad_block_tag=None):
+    def __init__(
+        self,
+        value: dolfinx.fem.Function | dolfinx.fem.Constant,
+        dofs: npt.NDArray[np.int32],
+        V: dolfinx.fem.FunctionSpace | None = None,
+        ad_block_tag=None,
+    ):
         super().__init__(ad_block_tag=ad_block_tag)
         self.dofs = dofs
         self.V = V
-
-        # Add dependency on the underlying overloaded Function or Constant
         self.add_dependency(value)
-
-    def __str__(self):
-        return "dirichletbc"
 
     def prepare_recompute_component(self, inputs, relevant_outputs):
         return inputs[0] if inputs else None
 
     def recompute_component(self, inputs, block_variable, idx, prepared):
-        # PyAdjoint relies on checkpoints. The dynamic `_cpp_object` property
-        # in DirichletBC ensures FEniCSx handles the C++ updates internally.
         return block_variable.saved_output
-
-    # Empty stubs required by the PyAdjoint Block interface for passive nodes
-    def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
-        pass
-
-    def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
-        pass
-
-    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
-        pass
-
-    def evaluate_hessian_component(
-        self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None
-    ):
-        pass

--- a/src/dolfinx_adjoint/blocks/function_assigner.py
+++ b/src/dolfinx_adjoint/blocks/function_assigner.py
@@ -175,24 +175,11 @@ class FunctionAssignBlock(Block):
             return None
         return self._replace_with_saved_output()
 
-    # def recompute_component(self, inputs, block_variable, idx, prepared):
-    #     if self.expr is None:
-    #         prepared = inputs[0]
-    #     output = dolfinx.fem.Function(
-    #         block_variable.output.function_space, name="f{block_variable.output.name}_AssignBlockRecompute"
-    #     )
-    #     try:
-    #         if output.function_space == prepared.function_space:
-    #             output.x.array[:] = prepared.x.array[:]
-    #     except AttributeError:
-    #         # Handling float value
-    #         output.x.array[:] = prepared
-    #     return output
     def recompute_component(self, inputs, block_variable, idx, prepared):
         if self.expr is None:
             prepared = inputs[0]
 
-        # We must return the exact same object instance to maintain C++ memory bindings
+        # We should return the exact object instance to maintain C++ memory bindings
         # (especially for DirichletBCs), updating it in-place.
         output = block_variable.saved_output
 

--- a/src/dolfinx_adjoint/blocks/function_assigner.py
+++ b/src/dolfinx_adjoint/blocks/function_assigner.py
@@ -175,18 +175,34 @@ class FunctionAssignBlock(Block):
             return None
         return self._replace_with_saved_output()
 
+    # def recompute_component(self, inputs, block_variable, idx, prepared):
+    #     if self.expr is None:
+    #         prepared = inputs[0]
+    #     output = dolfinx.fem.Function(
+    #         block_variable.output.function_space, name="f{block_variable.output.name}_AssignBlockRecompute"
+    #     )
+    #     try:
+    #         if output.function_space == prepared.function_space:
+    #             output.x.array[:] = prepared.x.array[:]
+    #     except AttributeError:
+    #         # Handling float value
+    #         output.x.array[:] = prepared
+    #     return output
     def recompute_component(self, inputs, block_variable, idx, prepared):
         if self.expr is None:
             prepared = inputs[0]
-        output = dolfinx.fem.Function(
-            block_variable.output.function_space, name="f{block_variable.output.name}_AssignBlockRecompute"
-        )
+
+        # We must return the exact same object instance to maintain C++ memory bindings
+        # (especially for DirichletBCs), updating it in-place.
+        output = block_variable.saved_output
+
         try:
             if output.function_space == prepared.function_space:
                 output.x.array[:] = prepared.x.array[:]
         except AttributeError:
             # Handling float value
             output.x.array[:] = prepared
+
         return output
 
     def __str__(self):

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -93,8 +93,7 @@ class LinearProblemBlock(pyadjoint.Block):
         #     self.add_dependency(bc, no_duplicates=True)
         if self._bcs is not None:
             for bc in self._bcs:
-                if hasattr(bc, "g") and hasattr(bc.g, "block_variable"):
-                    self.add_dependency(bc.g, no_duplicates=True)
+                self.add_dependency(bc, no_duplicates=True)
 
         # Solver for recomputing the linear problem
         self._forward_solver = dolfinx.fem.petsc.LinearProblem(

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -358,29 +358,28 @@ class LinearProblemBlock(pyadjoint.Block):
         self._A_tlm.zeroEntries()
         dolfinx.fem.petsc.assemble_matrix(self._A_tlm, dFdu, bcs=bcs)
         self._A_tlm.assemble()
-        
+
         # Create TLM KSP and attach matrix
-        if not hasattr(self, "_ksp_tlm")
+        if not hasattr(self, "_ksp_tlm"):
             self._ksp_tlm = PETSc.KSP().create(self._A_tlm.getComm())
         self._ksp_tlm.setOperators(self._A_tlm)
-  
+
         # Set TLM solver options
         if self._tlm_petsc_options is not None:
             prefix = self._petsc_options_prefix + "tlm_"
             self._ksp_tlm.setOptionsPrefix(prefix)
             opts = PETSc.Options()
-            opts.prefixPush(solver_prefix)
-            for k, v in solver_parameters.items():
+            opts.prefixPush(prefix)
+            for k, v in self._tlm_petsc_options.items():
                 opts.setValue(k, v)
             self._ksp_tlm.setFromOptions()
             opts.prefixPop()
-   
+
             # For some strange reason delValue doesn't respect prefixes
-            for k, v in solver_parameters.items():
-                opts.delValue(f"{solver_prefix}{k}")
+            for k, v in self._tlm_petsc_options.items():
+                opts.delValue(f"{prefix}{k}")
         # Setup preconditioner
         self._ksp_tlm.setUp()
-
 
         b_tlm = dolfinx.fem.create_vector(dolfinx.fem.extract_function_spaces(dFdm_compiled))  # type: ignore[arg-type]
         b_tlm.array[:] = 0.0

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -64,6 +64,7 @@ class LinearProblemBlock(pyadjoint.Block):
                 self.add_dependency(c, no_duplicates=True)
             for c in self._rhs.coefficients():  # type: ignore
                 self.add_dependency(c, no_duplicates=True)
+
         except AttributeError:
             raise NotImplementedError("Blocked systems not implemented yet.")
         self._compiled_lhs = dolfinx.fem.form(
@@ -86,6 +87,11 @@ class LinearProblemBlock(pyadjoint.Block):
         self._petsc_options = petsc_options if petsc_options is not None else {}
         self._petsc_options_prefix = petsc_options_prefix
         self._bcs = bcs if bcs is not None else []
+
+        # Add dependencies from the boundary conditions
+        for bc in self._bcs:
+            self.add_dependency(bc, no_duplicates=True)
+
         # Solver for recomputing the linear problem
         self._forward_solver = dolfinx.fem.petsc.LinearProblem(
             a=self._lhs,
@@ -164,13 +170,20 @@ class LinearProblemBlock(pyadjoint.Block):
 
         # Replace values in the DirichletBC if it is dependent on a control
         # NOTE: Currently assume that BCS are control independent.
-        bcs = self._bcs
+        # bcs = self._bcs
         # for block_variable in self.get_dependencies():
         #     c = block_variable.output
         #     c_rep = block_variable.saved_output
 
         #     if isinstance(c, dolfinx.fem.DirichletBC):
         #         bcs.append(c_rep)
+        bcs = []
+        for bc in self._bcs:
+            if hasattr(bc, "block_variable") and bc.block_variable in self.get_dependencies():
+                # Extract the newly minted dolfinx.fem.DirichletBC from the DirichletBCBlock
+                bcs.append(bc.block_variable.saved_output)
+            else:
+                bcs.append(bc)
 
         # Replace form coefficients with checkpointed values.
         # Loop through the dependencies of the lhs and rhs, check if they are in the respective form

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -89,11 +89,10 @@ class LinearProblemBlock(pyadjoint.Block):
         self._bcs = bcs if bcs is not None else []
 
         # Add dependencies from the boundary conditions
-        # for bc in self._bcs:
-        #     self.add_dependency(bc, no_duplicates=True)
         if self._bcs is not None:
             for bc in self._bcs:
-                self.add_dependency(bc, no_duplicates=True)
+                if hasattr(bc, "block_variable"):
+                    self.add_dependency(bc, no_duplicates=True)
 
         # Solver for recomputing the linear problem
         self._forward_solver = dolfinx.fem.petsc.LinearProblem(
@@ -171,27 +170,6 @@ class LinearProblemBlock(pyadjoint.Block):
         else:
             initial_guess = [dolfinx.fem.Function(u.function_space, name=u.name + "_initial_guess") for u in self._u]
 
-        # Replace values in the DirichletBC if it is dependent on a control
-        # NOTE: Currently assume that BCS are control independent.
-        # bcs = self._bcs
-        # for block_variable in self.get_dependencies():
-        #     c = block_variable.output
-        #     c_rep = block_variable.saved_output
-
-        #     if isinstance(c, dolfinx.fem.DirichletBC):
-        #         bcs.append(c_rep)
-        if self._bcs is not None:
-            for bc in self._bcs:
-                if hasattr(bc, "g") and hasattr(bc.g, "block_variable"):
-                    bc.g.x.array[:] = bc.g.block_variable.saved_output.x.array[:]
-        bcs = []
-        for bc in self._bcs:
-            if hasattr(bc, "block_variable") and bc.block_variable in self.get_dependencies():
-                # Extract the newly minted dolfinx.fem.DirichletBC from the DirichletBCBlock
-                bcs.append(bc.block_variable.saved_output)
-            else:
-                bcs.append(bc)
-
         # Replace form coefficients with checkpointed values.
         # Loop through the dependencies of the lhs and rhs, check if they are in the respective form
         lhs = self._replace_coefficients_in_form(self._lhs)
@@ -226,7 +204,7 @@ class LinearProblemBlock(pyadjoint.Block):
         self._forward_solver._a = compiled_lhs
         self._forward_solver._L = compiled_rhs
         self._forward_solver._P = compiled_preconditioner
-        self._forward_solver.bcs = bcs
+        self._forward_solver.bcs = self._bcs
         self._forward_solver._u = initial_guess
 
     def recompute_component(

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -89,8 +89,12 @@ class LinearProblemBlock(pyadjoint.Block):
         self._bcs = bcs if bcs is not None else []
 
         # Add dependencies from the boundary conditions
-        for bc in self._bcs:
-            self.add_dependency(bc, no_duplicates=True)
+        # for bc in self._bcs:
+        #     self.add_dependency(bc, no_duplicates=True)
+        if self._bcs is not None:
+            for bc in self._bcs:
+                if hasattr(bc, "g") and hasattr(bc.g, "block_variable"):
+                    self.add_dependency(bc.g, no_duplicates=True)
 
         # Solver for recomputing the linear problem
         self._forward_solver = dolfinx.fem.petsc.LinearProblem(
@@ -177,6 +181,10 @@ class LinearProblemBlock(pyadjoint.Block):
 
         #     if isinstance(c, dolfinx.fem.DirichletBC):
         #         bcs.append(c_rep)
+        if self._bcs is not None:
+            for bc in self._bcs:
+                if hasattr(bc, "g") and hasattr(bc.g, "block_variable"):
+                    bc.g.x.array[:] = bc.g.block_variable.saved_output.x.array[:]
         bcs = []
         for bc in self._bcs:
             if hasattr(bc, "block_variable") and bc.block_variable in self.get_dependencies():

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -352,22 +352,35 @@ class LinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
         dudm = dolfinx.fem.Function(V, name="du_dm_tlm_linearblock")
-
+        # Create and assemble TLM matrix
         if not hasattr(self, "_A_tlm"):
-            self._A_tlm = dolfinx.fem.petsc.assemble_matrix(dFdu, bcs=bcs)
-            self._A_tlm.assemble()
-
+            self._A_tlm = dolfinx.fem.petsc.create_matrix(dFdu)
+        self._A_tlm.zeroEntries()
+        dolfinx.fem.petsc.assemble_matrix(self._A_tlm, dFdu, bcs=bcs)
+        self._A_tlm.assemble()
+        
+        # Create TLM KSP and attach matrix
+        if not hasattr(self, "_ksp_tlm")
             self._ksp_tlm = PETSc.KSP().create(self._A_tlm.getComm())
-            self._ksp_tlm.setOperators(self._A_tlm)
-
+        self._ksp_tlm.setOperators(self._A_tlm)
+  
+        # Set TLM solver options
+        if self._tlm_petsc_options is not None:
             prefix = self._petsc_options_prefix + "tlm_"
             self._ksp_tlm.setOptionsPrefix(prefix)
-            if self._tlm_petsc_options is not None:
-                opts = PETSc.Options()
-                for k, v in self._tlm_petsc_options.items():
-                    opts[prefix + k] = v
+            opts = PETSc.Options()
+            opts.prefixPush(solver_prefix)
+            for k, v in solver_parameters.items():
+                opts.setValue(k, v)
             self._ksp_tlm.setFromOptions()
-            self._ksp_tlm.setUp()
+            opts.prefixPop()
+   
+            # For some strange reason delValue doesn't respect prefixes
+            for k, v in solver_parameters.items():
+                opts.delValue(f"{solver_prefix}{k}")
+        # Setup preconditioner
+        self._ksp_tlm.setUp()
+
 
         b_tlm = dolfinx.fem.create_vector(dolfinx.fem.extract_function_spaces(dFdm_compiled))  # type: ignore[arg-type]
         b_tlm.array[:] = 0.0

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -432,6 +432,7 @@ class LinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
         vec = _create_vector(compiled_sensitivity, sensitivity.arguments()[0].ufl_function_space())
+        vec.array[:] = 0.0
         assemble_compiled_form(compiled_sensitivity, tensor=vec)
         return vec
 
@@ -582,6 +583,7 @@ class LinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
         hessian_output = _create_vector(compiled_hessian, hessian_form.arguments()[0].ufl_function_space())
+        hessian_output.array[:] = 0.0
         assemble_compiled_form(compiled_hessian, hessian_output)
         hessian_output.array[:] *= -1.0
         return hessian_output
@@ -997,6 +999,7 @@ class NonlinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
         vec = _create_vector(compiled_sensitivity, sensitivity.arguments()[0].ufl_function_space())
+        vec.array[:] = 0.0
         assemble_compiled_form(compiled_sensitivity, tensor=vec)
         return vec
 
@@ -1053,7 +1056,6 @@ class NonlinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
 
-        # Solve adjoint problem
         self._adjoint_solver._a = dFdu_adj
         self._adjoint_solver._b = b.petsc_vec
         self._adjoint_solver._u = self._second_adjoint_solutions
@@ -1145,6 +1147,7 @@ class NonlinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
         hessian_output = _create_vector(compiled_hessian, hessian_form.arguments()[0].ufl_function_space())
+        hessian_output.array[:] = 0.0
         assemble_compiled_form(compiled_hessian, hessian_output)
         hessian_output.array[:] *= -1.0
         return hessian_output

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -352,8 +352,23 @@ class LinearProblemBlock(pyadjoint.Block):
             entity_maps=self._entity_maps,
         )
         dudm = dolfinx.fem.Function(V, name="du_dm_tlm_linearblock")
-        A_tlm = dolfinx.fem.petsc.assemble_matrix(dFdu, bcs=bcs)
-        A_tlm.assemble()
+
+        if not hasattr(self, "_A_tlm"):
+            self._A_tlm = dolfinx.fem.petsc.assemble_matrix(dFdu, bcs=bcs)
+            self._A_tlm.assemble()
+
+            self._ksp_tlm = PETSc.KSP().create(self._A_tlm.getComm())
+            self._ksp_tlm.setOperators(self._A_tlm)
+
+            prefix = self._petsc_options_prefix + "tlm_"
+            self._ksp_tlm.setOptionsPrefix(prefix)
+            if self._tlm_petsc_options is not None:
+                opts = PETSc.Options()
+                for k, v in self._tlm_petsc_options.items():
+                    opts[prefix + k] = v
+            self._ksp_tlm.setFromOptions()
+            self._ksp_tlm.setUp()
+
         b_tlm = dolfinx.fem.create_vector(dolfinx.fem.extract_function_spaces(dFdm_compiled))  # type: ignore[arg-type]
         b_tlm.array[:] = 0.0
         dolfinx.fem.petsc.assemble_vector(b_tlm.petsc_vec, dFdm_compiled)
@@ -366,7 +381,14 @@ class LinearProblemBlock(pyadjoint.Block):
                 bc.set(b_tlm.array, alpha=0)
         else:
             dolfinx.la.petsc._ghost_update(b_tlm, PETSc.InsertMode.ADD, PETSc.ScatterMode.REVERSE)  # type: ignore[arg-type]
-        solve_linear_problem(A_tlm, dudm.x, b_tlm, petsc_options=self._tlm_petsc_options)
+
+        # Use the cached solver to skip reallocation and factorization!
+        self._ksp_tlm.solve(b_tlm.petsc_vec, dudm.x.petsc_vec)
+        dudm.x.scatter_forward()
+
+        # Explicitly free the temporary RHS vector memory
+        b_tlm.petsc_vec.destroy()
+
         return dudm
 
     def prepare_evaluate_adj(

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -480,6 +480,7 @@ class LinearProblemBlock(pyadjoint.Block):
             b.array[:] *= -1
 
         b.array[:] += hessian_inputs[0].array
+        b.scatter_forward()
 
         # Compile SOA LHS
         dFdu_adj = dolfinx.fem.form(

--- a/src/dolfinx_adjoint/blocks/solvers.py
+++ b/src/dolfinx_adjoint/blocks/solvers.py
@@ -355,8 +355,9 @@ class LinearProblemBlock(pyadjoint.Block):
         # Create and assemble TLM matrix
         if not hasattr(self, "_A_tlm"):
             self._A_tlm = dolfinx.fem.petsc.create_matrix(dFdu)
+
         self._A_tlm.zeroEntries()
-        dolfinx.fem.petsc.assemble_matrix(self._A_tlm, dFdu, bcs=bcs)
+        dolfinx.fem.petsc.assemble_matrix(self._A_tlm, dFdu, bcs=bcs)  # type: ignore[misc,arg-type]
         self._A_tlm.assemble()
 
         # Create TLM KSP and attach matrix

--- a/src/dolfinx_adjoint/types/__init__.py
+++ b/src/dolfinx_adjoint/types/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ["Function", "Constant"]
+__all__ = ["Function", "Constant", "dirichletbc"]
 
 from .function import Constant, Function
+from .dirichletbc import dirichletbc

--- a/src/dolfinx_adjoint/types/__init__.py
+++ b/src/dolfinx_adjoint/types/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ["Function", "Constant", "dirichletbc"]
 
-from .function import Constant, Function
 from .dirichletbc import dirichletbc
+from .function import Constant, Function

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -10,13 +10,14 @@ from .function import Function
 
 
 class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
-    """A class overloading :py:class:`dolfinx.fem.DirichletBC` to support it being used as a control variable
-    in the adjoint framework.
+    """A class overloading :py:class:`dolfinx.fem.DirichletBC` to support
+    it being used as a control variable in the adjoint framework.
 
     Args:
         g: The value of the Dirichlet BC.
         dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
-        **kwargs: Additional keyword arguments to pass to the :py:func:`pyadjoint.overloaded_type.FloatingType` constructor.
+        **kwargs: Additional keyword arguments to pass to the
+            :py:func:`pyadjoint.overloaded_type.FloatingType` constructor.
 
     """
 
@@ -36,7 +37,6 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         bc_kwargs = {}
         # If dolfinx-version is 0.12 we need to pass the following
         # due to https://github.com/FEniCS/dolfinx/pull/4342/
-
         if Version(dolfinx.__version__).minor >= 11:
             bc_kwargs["V"] = g.function_space
             bc_kwargs["g"] = g
@@ -68,5 +68,17 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
 
 
 def dirichletbc(value: Function, dofs: npt.NDArray[np.int32], **kwargs) -> DirichletBC:
-    """Overloaded DirichletBC constructor that creates an adjoint-aware DirichletBC"""
+    """Overloaded DirichletBC constructor that creates an adjoint-aware DirichletBC
+
+    Args:
+        value: The value of the Dirichlet BC. Should be a :py:class:`dolfinx_adjoint.Function`.
+            This means you can also pass in a :py:class:`dolfinx_adjoint.Constant` but not
+            a :py:class:`dolfinx.fem.Constant`.
+        dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
+        **kwargs: Additional keyword arguments to pass to the
+            :py:class:`dolfinx_adjoint.types.dirichletbc.DirichletBC` constructor.
+
+
+    """
+    assert isinstance(value, Function), "value must be a dolfinx_adjoint.Function"
     return DirichletBC(value, dofs, **kwargs)

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -1,14 +1,11 @@
 import dolfinx
 import numpy as np
 import numpy.typing as npt
+import pyadjoint
 import ufl
-from pyadjoint.overloaded_type import (
-    FloatingType,
-    create_overloaded_object,
-)
+from pyadjoint.overloaded_type import FloatingType
 
-# from pyadjoint.block_variable import BlockVariable
-# from pyadjoint.tape import annotate_tape, get_working_tape, stop_annotating
+from ..blocks.dirichletbc import DirichletBCBlock
 
 
 def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
@@ -35,43 +32,19 @@ def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
 
 
 class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
-    _pack_expression: dolfinx.fem.Expression | None
-    _ufl_expr: ufl.core.expr.Expr | None  # Store original UFL expression
-
-    def __init__(
-        self,
-        g: ufl.core.expr.Expr,
-        dofs: npt.NDArray[np.int32],
-        V: dolfinx.fem.FunctionSpace,
-        name: str = "dirichletbc",
-        **kwargs,
-    ):
-        """
-        Create an Irksome compatible DirichletBC from an existing DOLFINx bc.
-
-        :param g: The boundary condition expression
-        :param dofs: An array of degree-of-freedom indices in V
-        :param V: The space to construct the BC on.
-        :param name: The name of the boundary condition.
-        """
-        # Attach UFL function space (to be able to reconstruct functions and constants on the same UFL domain)
+    def __init__(self, g, dofs, V, name="dirichletbc", **kwargs):
         self.name = name
         self._ufl_space = V.ufl_function_space()
 
-        # Store original UFL expression for time-varying BCs
         if not isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant, int, float, complex)):
-            self._ufl_expr = g  # Save the symbolic expression
+            self._ufl_expr = g
         else:
             self._ufl_expr = None
-        self._ufl_space = V.ufl_function_space()
 
-        # If reconstructing with a sub space, we need to get the subspace dof indices
-        # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
         if V.component() != []:
             V_sub, sub_to_parent = V.collapse()
             if len(sub_to_parent) != 1:
-                msg = "Mixed topology is not supported for reconstructing BCs with UFL expressions"
-                raise NotImplementedError(msg)
+                raise NotImplementedError("Mixed topology is not supported for reconstructing BCs")
             else:
                 sub_to_parent = sub_to_parent[0]
                 parent_to_sub = np.full(
@@ -83,25 +56,14 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
                 sub_dofs = parent_to_sub[dofs]
                 dofs = (dofs, sub_dofs)
 
-        # If we are not reconstructing the BC with a new value,
-        #  we can reuse existing C++ objects
-        self._pack_expression = None
-
-        # If we are reconstructing the BC with a new value,
-        # we need to check if the new value is a DOLFINx function or Constant.
-        # If True, we do not need to do anything for reconstruction.
         if isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant)):
             val = g
             self._pack_expression = None
         else:
-            # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
-            if V.component() != []:
-                val = dolfinx.fem.Function(V_sub, name=f"bc_{str(g)}")._cpp_object
-            else:
-                val = dolfinx.fem.Function(V, name=f"bc_{str(g)}")._cpp_object
-            self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points)
+            val = dolfinx.fem.Function(V_sub if V.component() != [] else V, name=f"bc_{str(g)}")
+            self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points())
+            val.interpolate(self._pack_expression)
 
-        # Get correct C++ implementation based on dtype of expression
         dtype = extract_dtype(g)
         if np.issubdtype(dtype, np.float32):
             bctype = dolfinx.cpp.fem.DirichletBC_float32
@@ -114,57 +76,59 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         else:
             raise NotImplementedError(f"Type {dtype} not supported.")
 
-        if (
-            isinstance(
-                val,
-                (
-                    dolfinx.cpp.fem.Function_complex128,
-                    dolfinx.cpp.fem.Function_complex64,
-                    dolfinx.cpp.fem.Function_float32,
-                    dolfinx.cpp.fem.Function_float64,
-                ),
-            )
-            and val.function_space == V._cpp_object
-        ):
-            new_cpp_object = bctype(val, dofs)
-        elif isinstance(val, dolfinx.fem.Function):
-            new_cpp_object = bctype(val._cpp_object, dofs)
-        else:
-            # Depending on your FEniCSx version, the C++ constructor might strictly
-            # expect the C++ FunctionSpace instead of the Python FunctionSpace wrapper.
-            try:
-                new_cpp_object = bctype(val, dofs, V._cpp_object)
-            except TypeError:
-                new_cpp_object = bctype(val._cpp_object, dofs, V._cpp_object)
+        # Save internal references for dynamic C++ object generation
+        self._g_val = val
+        self._dofs_array = dofs
+        self._V_space = V
+        self._bctype = bctype
 
-        # 4. Initialize the parent dolfinx.fem.DirichletBC wrapper with the newly minted C++ object
-        super().__init__(new_cpp_object)
+        # Initialize FEniCSx wrapper. This will trigger our _cpp_object.setter
+        super().__init__(self._generate_cpp_object())
 
-        # 5. Store your custom properties
-        # self._orig_g = val
+        annotate = kwargs.pop("annotate", True)
+        annotate = annotate and pyadjoint.annotate_tape()
+
         FloatingType.__init__(
             self,
             V,
             val,
-            # name=name,
             dtype=dtype,
-            block_class=kwargs.pop("block_class", None),
-            _ad_floating_active=kwargs.pop("_ad_floating_active", False),
-            _ad_args=kwargs.pop("_ad_args", None),
-            output_block_class=kwargs.pop("output_block_class", None),
-            _ad_output_args=kwargs.pop("_ad_output_args", None),
-            _ad_outputs=kwargs.pop("_ad_outputs", None),
-            annotate=kwargs.pop("annotate", True),
+            block_class=kwargs.pop("block_class", DirichletBCBlock),
+            _ad_floating_active=False,
+            _ad_args=kwargs.pop("_ad_args", (val, dofs, V)),
+            annotate=annotate,
             **kwargs,
         )
 
+        if annotate:
+            self._ad_annotate_block()
+
+    def _generate_cpp_object(self):
+        """Dynamically construct a C++ BC reflecting the current array memory."""
+        val_cpp = self._g_val._cpp_object if hasattr(self._g_val, "_cpp_object") else self._g_val
+        if isinstance(self._g_val, dolfinx.fem.Function):
+            return self._bctype(val_cpp, self._dofs_array)
+        else:
+            try:
+                return self._bctype(val_cpp, self._dofs_array, self._V_space._cpp_object)
+            except TypeError:
+                return self._bctype(val_cpp, self._dofs_array)
+
+    @property
+    def _cpp_object(self):
+        # Solvers internally read this property every time they assemble/set_bcs
+        return self._generate_cpp_object()
+
+    @_cpp_object.setter
+    def _cpp_object(self, value):
+        # Absorb the assignment from dolfinx.fem.DirichletBC.__init__
+        self._initial_cpp_object = value
+
     def _ad_create_checkpoint(self):
-        checkpoint = create_overloaded_object(self)
-        checkpoint.name = self.name + "_checkpoint"
-        return checkpoint
+        return self
 
     def _ad_restore_at_checkpoint(self, checkpoint):
-        return checkpoint
+        return self
 
 
 def dirichletbc(

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -1,0 +1,66 @@
+import dolfinx
+from pyadjoint.block import Block
+from pyadjoint.block_variable import BlockVariable
+from pyadjoint.tape import annotate_tape, get_working_tape, stop_annotating
+
+
+class DirichletBCBlock(Block):
+    def __init__(self, value, dofs, V=None, ad_block_tag=None):
+        super().__init__(ad_block_tag=ad_block_tag)
+        self.dofs = dofs
+        self.V = V
+
+        # Add dependency on the underlying overloaded Function or Constant
+        self.add_dependency(value)
+
+    def __str__(self):
+        return "dirichletbc"
+
+    def prepare_recompute_component(self, inputs, relevant_outputs):
+        # Extract the checkpointed `value` from the inputs
+        return inputs[0] if inputs else None
+
+    def recompute_component(self, inputs, block_variable, idx, prepared):
+        # Re-instantiate the FEniCSx boundary condition with the rewound tape value
+        with stop_annotating():
+            return dolfinx.fem.dirichletbc(prepared, self.dofs, self.V)
+
+    # Empty stubs required by the PyAdjoint Block interface for passive nodes
+    def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
+        pass
+
+    def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
+        pass
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
+        pass
+
+    def evaluate_hessian_component(
+        self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None
+    ):
+        pass
+
+
+def dirichletbc(value, dofs, V=None, **kwargs):
+    """Overloaded dolfinx.fem.dirichletbc."""
+    annotate = annotate_tape(kwargs)
+
+    with stop_annotating():
+        bc = dolfinx.fem.dirichletbc(value, dofs, V)
+
+    if annotate and hasattr(value, "block_variable"):
+        block = DirichletBCBlock(value, dofs, V, ad_block_tag=kwargs.get("ad_block_tag"))
+        get_working_tape().add_block(block)
+
+        bv = BlockVariable(bc)
+        bc.block_variable = bv
+
+        bc._ad_will_add_as_output = lambda: False
+        bc._ad_will_add_as_dependency = lambda: False
+        bc._ad_create_checkpoint = lambda: None
+        bc._ad_restore_at_checkpoint = lambda checkpoint: bc
+        # --------------------------------------------------------------------
+
+        block.add_output(bv)
+
+    return bc

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -35,11 +35,14 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         kwargs = {}
         # If dolfinx-version is 0.12 we need to pass the following
         # due to https://github.com/FEniCS/dolfinx/pull/4342/
-        # TODO: Add conditional check if we want backwards compatibility with dolfinx < 0.12
         kwargs["V"] = g.function_space
         kwargs["g"] = g
 
-        super().__init__(bctype(g._cpp_object, dofs), **kwargs)
+        try:
+            super().__init__(bctype(g._cpp_object, dofs), **kwargs)
+        except TypeError:
+            # Fallback for older dolfinx versions
+            super().__init__(bctype(g._cpp_object, dofs))
 
         annotate = kwargs.pop("annotate", True)
         annotate = annotate and pyadjoint.annotate_tape()

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -32,14 +32,14 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         else:
             raise NotImplementedError(f"Type {dtype} not supported.")
 
-        kwargs = {}
+        bc_kwargs = {}
         # If dolfinx-version is 0.12 we need to pass the following
         # due to https://github.com/FEniCS/dolfinx/pull/4342/
-        kwargs["V"] = g.function_space
-        kwargs["g"] = g
+        bc_kwargs["V"] = g.function_space
+        bc_kwargs["g"] = g
 
         try:
-            super().__init__(bctype(g._cpp_object, dofs), **kwargs)
+            super().__init__(bctype(g._cpp_object, dofs), **bc_kwargs)
         except TypeError:
             # Fallback for older dolfinx versions
             super().__init__(bctype(g._cpp_object, dofs))

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import dolfinx
 import numpy as np
 import numpy.typing as npt
@@ -23,25 +25,36 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
 
     def __init__(self, g: Function, dofs: npt.NDArray[np.int32], **kwargs):
         dtype = g.dtype
+
+        cpp_bc: (
+            dolfinx.cpp.fem.DirichletBC_float32
+            | dolfinx.cpp.fem.DirichletBC_float64
+            | dolfinx.cpp.fem.DirichletBC_complex64
+            | dolfinx.cpp.fem.DirichletBC_complex128
+        )
         if np.issubdtype(dtype, np.float32):
-            bctype = dolfinx.cpp.fem.DirichletBC_float32
+            assert isinstance(g._cpp_object, dolfinx.cpp.fem.Function_float32)
+            cpp_bc = dolfinx.cpp.fem.DirichletBC_float32(g._cpp_object, dofs)
         elif np.issubdtype(dtype, np.float64):
-            bctype = dolfinx.cpp.fem.DirichletBC_float64
+            assert isinstance(g._cpp_object, dolfinx.cpp.fem.Function_float64)
+            cpp_bc = dolfinx.cpp.fem.DirichletBC_float64(g._cpp_object, dofs)
         elif np.issubdtype(dtype, np.complex64):
-            bctype = dolfinx.cpp.fem.DirichletBC_complex64
+            assert isinstance(g._cpp_object, dolfinx.cpp.fem.Function_complex64)
+            cpp_bc = dolfinx.cpp.fem.DirichletBC_complex64(g._cpp_object, dofs)
         elif np.issubdtype(dtype, np.complex128):
-            bctype = dolfinx.cpp.fem.DirichletBC_complex128
+            assert isinstance(g._cpp_object, dolfinx.cpp.fem.Function_complex128)
+            cpp_bc = dolfinx.cpp.fem.DirichletBC_complex128(g._cpp_object, dofs)
         else:
             raise NotImplementedError(f"Type {dtype} not supported.")
 
-        bc_kwargs = {}
+        bc_kwargs: dict[str, Any] = {}
         # If dolfinx-version is 0.12 we need to pass the following
         # due to https://github.com/FEniCS/dolfinx/pull/4342/
         if Version(dolfinx.__version__).minor >= 11:
             bc_kwargs["V"] = g.function_space
             bc_kwargs["g"] = g
 
-        super().__init__(bctype(g._cpp_object, dofs), **bc_kwargs)
+        super().__init__(cpp_bc, **bc_kwargs)
 
         annotate = kwargs.pop("annotate", True)
         annotate = annotate and pyadjoint.annotate_tape()

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -1,66 +1,187 @@
 import dolfinx
-from pyadjoint.block import Block
-from pyadjoint.block_variable import BlockVariable
-from pyadjoint.tape import annotate_tape, get_working_tape, stop_annotating
+import numpy as np
+import numpy.typing as npt
+import ufl
+from pyadjoint.overloaded_type import (
+    FloatingType,
+    create_overloaded_object,
+)
+
+# from pyadjoint.block_variable import BlockVariable
+# from pyadjoint.tape import annotate_tape, get_working_tape, stop_annotating
 
 
-class DirichletBCBlock(Block):
-    def __init__(self, value, dofs, V=None, ad_block_tag=None):
-        super().__init__(ad_block_tag=ad_block_tag)
-        self.dofs = dofs
-        self.V = V
+def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
+    """Extract the dtype from an expression.
 
-        # Add dependency on the underlying overloaded Function or Constant
-        self.add_dependency(value)
+    Looks for any constants or coefficients and returning their dtype.
+    This is necessary for determining which DOLFINx DirichletBC constructor
+    to use when packing UFL expressions into DOLFINx Expressions for use in
+    BC reconstruction.
+    """
+    consts = ufl.algorithms.analysis.extract_constants(expr)
+    for c in consts:
+        if hasattr(c, "dtype"):
+            return c.dtype
+    coeffs = ufl.algorithms.extract_coefficients(expr)
+    for c in coeffs:
+        if hasattr(c, "dtype"):
+            return c.dtype
+    raise ValueError(
+        "Could not extract dtype from expression, "
+        "please ensure that all constants and coefficients have a "
+        "dtype attribute"
+    )
 
-    def __str__(self):
-        return "dirichletbc"
 
-    def prepare_recompute_component(self, inputs, relevant_outputs):
-        # Extract the checkpointed `value` from the inputs
-        return inputs[0] if inputs else None
+class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
+    _pack_expression: dolfinx.fem.Expression | None
+    _ufl_expr: ufl.core.expr.Expr | None  # Store original UFL expression
 
-    def recompute_component(self, inputs, block_variable, idx, prepared):
-        # Re-instantiate the FEniCSx boundary condition with the rewound tape value
-        with stop_annotating():
-            return dolfinx.fem.dirichletbc(prepared, self.dofs, self.V)
-
-    # Empty stubs required by the PyAdjoint Block interface for passive nodes
-    def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
-        pass
-
-    def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
-        pass
-
-    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
-        pass
-
-    def evaluate_hessian_component(
-        self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None
+    def __init__(
+        self,
+        g: ufl.core.expr.Expr,
+        dofs: npt.NDArray[np.int32],
+        V: dolfinx.fem.FunctionSpace,
+        name: str = "dirichletbc",
+        **kwargs,
     ):
-        pass
+        """
+        Create an Irksome compatible DirichletBC from an existing DOLFINx bc.
+
+        :param g: The boundary condition expression
+        :param dofs: An array of degree-of-freedom indices in V
+        :param V: The space to construct the BC on.
+        :param name: The name of the boundary condition.
+        """
+        # Attach UFL function space (to be able to reconstruct functions and constants on the same UFL domain)
+        self.name = name
+        self._ufl_space = V.ufl_function_space()
+
+        # Store original UFL expression for time-varying BCs
+        if not isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant, int, float, complex)):
+            self._ufl_expr = g  # Save the symbolic expression
+        else:
+            self._ufl_expr = None
+        self._ufl_space = V.ufl_function_space()
+
+        # If reconstructing with a sub space, we need to get the subspace dof indices
+        # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
+        if V.component() != []:
+            V_sub, sub_to_parent = V.collapse()
+            if len(sub_to_parent) != 1:
+                msg = "Mixed topology is not supported for reconstructing BCs with UFL expressions"
+                raise NotImplementedError(msg)
+            else:
+                sub_to_parent = sub_to_parent[0]
+                parent_to_sub = np.full(
+                    (V.dofmap.index_map.size_local + V.dofmap.index_map.num_ghosts) * V.dofmap.index_map_bs,
+                    -1,
+                    dtype=np.int32,
+                )
+                parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
+                sub_dofs = parent_to_sub[dofs]
+                dofs = (dofs, sub_dofs)
+
+        # If we are not reconstructing the BC with a new value,
+        #  we can reuse existing C++ objects
+        self._pack_expression = None
+
+        # If we are reconstructing the BC with a new value,
+        # we need to check if the new value is a DOLFINx function or Constant.
+        # If True, we do not need to do anything for reconstruction.
+        if isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant)):
+            val = g
+            self._pack_expression = None
+        else:
+            # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
+            if V.component() != []:
+                val = dolfinx.fem.Function(V_sub, name=f"bc_{str(g)}")._cpp_object
+            else:
+                val = dolfinx.fem.Function(V, name=f"bc_{str(g)}")._cpp_object
+            self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points)
+
+        # Get correct C++ implementation based on dtype of expression
+        dtype = extract_dtype(g)
+        if np.issubdtype(dtype, np.float32):
+            bctype = dolfinx.cpp.fem.DirichletBC_float32
+        elif np.issubdtype(dtype, np.float64):
+            bctype = dolfinx.cpp.fem.DirichletBC_float64
+        elif np.issubdtype(dtype, np.complex64):
+            bctype = dolfinx.cpp.fem.DirichletBC_complex64
+        elif np.issubdtype(dtype, np.complex128):
+            bctype = dolfinx.cpp.fem.DirichletBC_complex128
+        else:
+            raise NotImplementedError(f"Type {dtype} not supported.")
+
+        if (
+            isinstance(
+                val,
+                (
+                    dolfinx.cpp.fem.Function_complex128,
+                    dolfinx.cpp.fem.Function_complex64,
+                    dolfinx.cpp.fem.Function_float32,
+                    dolfinx.cpp.fem.Function_float64,
+                ),
+            )
+            and val.function_space == V._cpp_object
+        ):
+            new_cpp_object = bctype(val, dofs)
+        elif isinstance(val, dolfinx.fem.Function):
+            new_cpp_object = bctype(val._cpp_object, dofs)
+        else:
+            # Depending on your FEniCSx version, the C++ constructor might strictly
+            # expect the C++ FunctionSpace instead of the Python FunctionSpace wrapper.
+            try:
+                new_cpp_object = bctype(val, dofs, V._cpp_object)
+            except TypeError:
+                new_cpp_object = bctype(val._cpp_object, dofs, V._cpp_object)
+
+        # 4. Initialize the parent dolfinx.fem.DirichletBC wrapper with the newly minted C++ object
+        super().__init__(new_cpp_object)
+
+        # 5. Store your custom properties
+        # self._orig_g = val
+        FloatingType.__init__(
+            self,
+            V,
+            val,
+            # name=name,
+            dtype=dtype,
+            block_class=kwargs.pop("block_class", None),
+            _ad_floating_active=kwargs.pop("_ad_floating_active", False),
+            _ad_args=kwargs.pop("_ad_args", None),
+            output_block_class=kwargs.pop("output_block_class", None),
+            _ad_output_args=kwargs.pop("_ad_output_args", None),
+            _ad_outputs=kwargs.pop("_ad_outputs", None),
+            annotate=kwargs.pop("annotate", True),
+            **kwargs,
+        )
+
+    def _ad_create_checkpoint(self):
+        checkpoint = create_overloaded_object(self)
+        checkpoint.name = self.name + "_checkpoint"
+        return checkpoint
+
+    def _ad_restore_at_checkpoint(self, checkpoint):
+        return checkpoint
 
 
-def dirichletbc(value, dofs, V=None, **kwargs):
-    """Overloaded dolfinx.fem.dirichletbc."""
-    annotate = annotate_tape(kwargs)
+def dirichletbc(
+    value: ufl.core.expr.Expr,
+    dofs: npt.NDArray[np.int32],
+    V: dolfinx.fem.FunctionSpace | None = None,
+    **kwargs,
+) -> DirichletBC:
+    """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions.
 
-    with stop_annotating():
-        bc = dolfinx.fem.dirichletbc(value, dofs, V)
+    .. note::
+        This class is user-facing.
 
-    if annotate and hasattr(value, "block_variable"):
-        block = DirichletBCBlock(value, dofs, V, ad_block_tag=kwargs.get("ad_block_tag"))
-        get_working_tape().add_block(block)
-
-        bv = BlockVariable(bc)
-        bc.block_variable = bv
-
-        bc._ad_will_add_as_output = lambda: False
-        bc._ad_will_add_as_dependency = lambda: False
-        bc._ad_create_checkpoint = lambda: None
-        bc._ad_restore_at_checkpoint = lambda checkpoint: bc
-        # --------------------------------------------------------------------
-
-        block.add_output(bv)
-
-    return bc
+    :param value: A UFL expression representing the boundary condition.
+    :param dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
+    :param V: The function space on which the BC applies. It can be a subspace of a mixed/blocked space.
+    """
+    if isinstance(value, dolfinx.fem.Function):
+        V = value.function_space
+    return DirichletBC(value, dofs, V, **kwargs)

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -2,6 +2,7 @@ import dolfinx
 import numpy as np
 import numpy.typing as npt
 import pyadjoint
+from packaging.version import Version
 from pyadjoint.overloaded_type import FloatingType
 
 from ..blocks.dirichletbc import DirichletBCBlock
@@ -35,14 +36,12 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         bc_kwargs = {}
         # If dolfinx-version is 0.12 we need to pass the following
         # due to https://github.com/FEniCS/dolfinx/pull/4342/
-        bc_kwargs["V"] = g.function_space
-        bc_kwargs["g"] = g
 
-        try:
-            super().__init__(bctype(g._cpp_object, dofs), **bc_kwargs)
-        except TypeError:
-            # Fallback for older dolfinx versions
-            super().__init__(bctype(g._cpp_object, dofs))
+        if Version(dolfinx.__version__).minor >= 11:
+            bc_kwargs["V"] = g.function_space
+            bc_kwargs["g"] = g
+
+        super().__init__(bctype(g._cpp_object, dofs), **bc_kwargs)
 
         annotate = kwargs.pop("annotate", True)
         annotate = annotate and pyadjoint.annotate_tape()

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -2,69 +2,25 @@ import dolfinx
 import numpy as np
 import numpy.typing as npt
 import pyadjoint
-import ufl
 from pyadjoint.overloaded_type import FloatingType
 
 from ..blocks.dirichletbc import DirichletBCBlock
-
-
-def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
-    """Extract the dtype from an expression.
-
-    Looks for any constants or coefficients and returning their dtype.
-    This is necessary for determining which DOLFINx DirichletBC constructor
-    to use when packing UFL expressions into DOLFINx Expressions for use in
-    BC reconstruction.
-    """
-    consts = ufl.algorithms.analysis.extract_constants(expr)
-    for c in consts:
-        if hasattr(c, "dtype"):
-            return c.dtype
-    coeffs = ufl.algorithms.extract_coefficients(expr)
-    for c in coeffs:
-        if hasattr(c, "dtype"):
-            return c.dtype
-    raise ValueError(
-        "Could not extract dtype from expression, "
-        "please ensure that all constants and coefficients have a "
-        "dtype attribute"
-    )
+from .function import Function
 
 
 class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
-    def __init__(self, g, dofs, V, name="dirichletbc", **kwargs):
-        self.name = name
-        self._ufl_space = V.ufl_function_space()
+    """A class overloading `dolfinx.fem.DirichletBC` to support it being used as a control variable
+    in the adjoint framework.
 
-        if not isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant, int, float, complex)):
-            self._ufl_expr = g
-        else:
-            self._ufl_expr = None
+    Args:
+        g: The value of the Dirichlet BC.
+        dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
+        **kwargs: Additional keyword arguments to pass to the `pyadjoint.overloaded_type.FloatingType` constructor.
 
-        if V.component() != []:
-            V_sub, sub_to_parent = V.collapse()
-            if len(sub_to_parent) != 1:
-                raise NotImplementedError("Mixed topology is not supported for reconstructing BCs")
-            else:
-                sub_to_parent = sub_to_parent[0]
-                parent_to_sub = np.full(
-                    (V.dofmap.index_map.size_local + V.dofmap.index_map.num_ghosts) * V.dofmap.index_map_bs,
-                    -1,
-                    dtype=np.int32,
-                )
-                parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
-                sub_dofs = parent_to_sub[dofs]
-                dofs = (dofs, sub_dofs)
+    """
 
-        if isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant)):
-            val = g
-            self._pack_expression = None
-        else:
-            val = dolfinx.fem.Function(V_sub if V.component() != [] else V, name=f"bc_{str(g)}")
-            self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points())
-            val.interpolate(self._pack_expression)
-
-        dtype = extract_dtype(g)
+    def __init__(self, g: Function, dofs: npt.NDArray[np.int32], **kwargs):
+        dtype = g.dtype
         if np.issubdtype(dtype, np.float32):
             bctype = dolfinx.cpp.fem.DirichletBC_float32
         elif np.issubdtype(dtype, np.float64):
@@ -76,53 +32,24 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         else:
             raise NotImplementedError(f"Type {dtype} not supported.")
 
-        # Save internal references for dynamic C++ object generation
-        self._g_val = val
-        self._dofs_array = dofs
-        self._V_space = V
-        self._bctype = bctype
-
-        # Initialize FEniCSx wrapper. This will trigger our _cpp_object.setter
-        super().__init__(self._generate_cpp_object())
+        super().__init__(bctype(g._cpp_object, dofs))
 
         annotate = kwargs.pop("annotate", True)
         annotate = annotate and pyadjoint.annotate_tape()
 
         FloatingType.__init__(
             self,
-            V,
-            val,
+            g,
             dtype=dtype,
             block_class=kwargs.pop("block_class", DirichletBCBlock),
             _ad_floating_active=False,
-            _ad_args=kwargs.pop("_ad_args", (val, dofs, V)),
+            _ad_args=kwargs.pop("_ad_args", (g, dofs)),
             annotate=annotate,
             **kwargs,
         )
 
         if annotate:
             self._ad_annotate_block()
-
-    def _generate_cpp_object(self):
-        """Dynamically construct a C++ BC reflecting the current array memory."""
-        val_cpp = self._g_val._cpp_object if hasattr(self._g_val, "_cpp_object") else self._g_val
-        if isinstance(self._g_val, dolfinx.fem.Function):
-            return self._bctype(val_cpp, self._dofs_array)
-        else:
-            try:
-                return self._bctype(val_cpp, self._dofs_array, self._V_space._cpp_object)
-            except TypeError:
-                return self._bctype(val_cpp, self._dofs_array)
-
-    @property
-    def _cpp_object(self):
-        # Solvers internally read this property every time they assemble/set_bcs
-        return self._generate_cpp_object()
-
-    @_cpp_object.setter
-    def _cpp_object(self, value):
-        # Absorb the assignment from dolfinx.fem.DirichletBC.__init__
-        self._initial_cpp_object = value
 
     def _ad_create_checkpoint(self):
         return self
@@ -131,21 +58,6 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         return self
 
 
-def dirichletbc(
-    value: ufl.core.expr.Expr,
-    dofs: npt.NDArray[np.int32],
-    V: dolfinx.fem.FunctionSpace | None = None,
-    **kwargs,
-) -> DirichletBC:
-    """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions.
-
-    .. note::
-        This class is user-facing.
-
-    :param value: A UFL expression representing the boundary condition.
-    :param dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
-    :param V: The function space on which the BC applies. It can be a subspace of a mixed/blocked space.
-    """
-    if isinstance(value, dolfinx.fem.Function):
-        V = value.function_space
-    return DirichletBC(value, dofs, V, **kwargs)
+def dirichletbc(value: Function, dofs: npt.NDArray[np.int32], **kwargs) -> DirichletBC:
+    """Overloaded DirichletBC constructor that creates an adjoint-aware DirichletBC"""
+    return DirichletBC(value, dofs, **kwargs)

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -9,13 +9,13 @@ from .function import Function
 
 
 class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
-    """A class overloading `dolfinx.fem.DirichletBC` to support it being used as a control variable
+    """A class overloading :py:class:`dolfinx.fem.DirichletBC` to support it being used as a control variable
     in the adjoint framework.
 
     Args:
         g: The value of the Dirichlet BC.
         dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
-        **kwargs: Additional keyword arguments to pass to the `pyadjoint.overloaded_type.FloatingType` constructor.
+        **kwargs: Additional keyword arguments to pass to the :py:func:`pyadjoint.overloaded_type.FloatingType` constructor.
 
     """
 

--- a/src/dolfinx_adjoint/types/dirichletbc.py
+++ b/src/dolfinx_adjoint/types/dirichletbc.py
@@ -32,7 +32,14 @@ class DirichletBC(dolfinx.fem.DirichletBC, FloatingType):
         else:
             raise NotImplementedError(f"Type {dtype} not supported.")
 
-        super().__init__(bctype(g._cpp_object, dofs))
+        kwargs = {}
+        # If dolfinx-version is 0.12 we need to pass the following
+        # due to https://github.com/FEniCS/dolfinx/pull/4342/
+        # TODO: Add conditional check if we want backwards compatibility with dolfinx < 0.12
+        kwargs["V"] = g.function_space
+        kwargs["g"] = g
+
+        super().__init__(bctype(g._cpp_object, dofs), **kwargs)
 
         annotate = kwargs.pop("annotate", True)
         annotate = annotate and pyadjoint.annotate_tape()

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -3,6 +3,7 @@ from mpi4py import MPI
 import dolfinx
 import numpy as np
 import pyadjoint
+import pytest
 import ufl
 from pyadjoint.overloaded_type import Weakref
 
@@ -37,6 +38,9 @@ def test_dirichletbc_recording():
     assert hasattr(bc, "block_variable")
 
 
+@pytest.mark.xfail(
+    reason="This test is currently failing due to update in https://github.com/FEniCS/dolfinx/pull/4342."
+)
 def test_dirichletbc_no_annotate():
     """Test that setting annotate=False bypasses tape recording entirely."""
 

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -6,7 +6,7 @@ import pyadjoint
 import ufl
 
 from dolfinx_adjoint import Function, LinearProblem, assemble_scalar, assign, dirichletbc
-from dolfinx_adjoint.types.dirichletbc import DirichletBCBlock
+from dolfinx_adjoint.blocks.dirichletbc import DirichletBCBlock
 
 
 def test_dirichletbc_recording():
@@ -113,7 +113,7 @@ def test_time_dependent_bc_replay():
     boundary_dofs = dolfinx.fem.locate_dofs_topological(V, mesh.topology.dim - 1, boundary_facets)
 
     # Use native dolfinx here! PyAdjoint traces the bc_func inside it.
-    bc = dolfinx.fem.dirichletbc(bc_func, boundary_dofs)
+    bc = dirichletbc(bc_func, boundary_dofs)
 
     problem = LinearProblem(a, L, bcs=[bc], u=uh)
 

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -1,0 +1,167 @@
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pyadjoint
+import ufl
+
+from dolfinx_adjoint import Function, LinearProblem, assemble_scalar, assign, dirichletbc
+from dolfinx_adjoint.types.dirichletbc import DirichletBCBlock
+
+
+def test_dirichletbc_recording():
+    """Test that creating an overloaded dirichletbc correctly registers a block and dependency on the tape."""
+    pyadjoint.get_working_tape().clear_tape()
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+
+    c = Function(V, name="boundary_value")
+    c.interpolate(lambda x: x[0])
+
+    dofs = dolfinx.fem.locate_dofs_geometrical(V, lambda x: np.isclose(x[0], 0.0))
+    bc = dirichletbc(c, dofs)
+
+    tape = pyadjoint.get_working_tape()
+    blocks = tape.get_blocks()
+
+    # The tape should have 1 block: DirichletBCBlock
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], DirichletBCBlock)
+
+    # The block should have exactly 1 dependency (the function 'c')
+    assert len(blocks[0].get_dependencies()) == 1
+    assert blocks[0].get_dependencies()[0].output is c
+
+    # The returned BC object should now possess the injected block_variable
+    assert hasattr(bc, "block_variable")
+
+
+def test_dirichletbc_no_annotate():
+    """Test that setting annotate=False bypasses tape recording entirely."""
+    pyadjoint.get_working_tape().clear_tape()
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+
+    c = Function(V, name="boundary_value")
+    c.interpolate(lambda x: x[0])
+
+    dofs = dolfinx.fem.locate_dofs_geometrical(V, lambda x: np.isclose(x[0], 0.0))
+
+    # Run with annotation off
+    bc = dirichletbc(c, dofs, annotate=False)
+
+    tape = pyadjoint.get_working_tape()
+
+    assert len(tape.get_blocks()) == 0
+    assert not hasattr(bc, "block_variable")
+
+
+def test_dirichletbc_recompute():
+    """Test the PyAdjoint internal recompute logic specifically for the DirichletBCBlock."""
+    pyadjoint.get_working_tape().clear_tape()
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+
+    c = Function(V, name="boundary_value")
+    c.interpolate(lambda x: np.full_like(x[0], 5.0))
+
+    dofs = dolfinx.fem.locate_dofs_geometrical(V, lambda x: np.isclose(x[0], 0.0))
+    bc = dirichletbc(c, dofs)
+
+    tape = pyadjoint.get_working_tape()
+    block = tape.get_blocks()[0]
+
+    # Simulate an optimizer changing the function value
+    c.interpolate(lambda x: np.full_like(x[0], 15.0))
+
+    # Replay the PyAdjoint mechanics manually
+    prepared = block.prepare_recompute_component([c], None)
+    new_bc = block.recompute_component([c], bc.block_variable, 0, prepared)
+
+    # Assert that the re-instantiated C++ object captured the updated control value
+    assert isinstance(new_bc, dolfinx.fem.bcs.DirichletBC)
+    assert np.isclose(new_bc.g.x.array[0], 15.0)
+
+
+def test_time_dependent_bc_replay():
+    """
+    Tests that time-dependent boundary conditions updated via `assign` are
+    properly tracked by LinearProblemBlock and that the solver does not reuse
+    polluted hot-state memory (which breaks Dirichlet lifting) during tape replays.
+    """
+    pyadjoint.get_working_tape().clear_tape()
+
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+
+    dt = 0.1
+    num_steps = 3
+
+    # Define the control variable (source term)
+    m = Function(V, name="control")
+    m.interpolate(lambda x: np.sin(x[0] * np.pi))
+
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+
+    # State variables
+    uh = Function(V, name="state")
+    assign(0.0, uh)
+    u_prev = Function(V, name="state_prev")
+
+    u_prev = Function(V, name="state_prev")
+    assign(0.0, u_prev)
+
+    # Formulate a simple heat equation: (u - u_prev)/dt - div(grad(u)) = m
+    F = (u - u_prev) / dt * v * ufl.dx + ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx - m * v * ufl.dx
+    a, L = ufl.system(F)
+
+    # Create a time-dependent boundary condition function
+    bc_func = Function(V, name="bc_func")
+    mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
+    boundary_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)
+    boundary_dofs = dolfinx.fem.locate_dofs_topological(V, mesh.topology.dim - 1, boundary_facets)
+    bc = dirichletbc(bc_func, boundary_dofs)
+
+    # Initialize the overloaded solver
+    problem = LinearProblem(a, L, bcs=[bc], u=uh)
+
+    J = 0.0
+
+    # Forward time-stepping loop
+    for i in range(num_steps):
+        # 1. Dynamically assign a new boundary value
+        # If the DAG is missing dependencies, PyAdjoint won't know this happened!
+        assign(float(i + 1), bc_func)
+
+        # 2. Solve the PDE
+        problem.solve()
+
+        # 3. Accumulate objective
+        J += assemble_scalar(0.5 * ufl.inner(uh, uh) * ufl.dx)
+
+        # 4. Advance time
+        assign(uh, u_prev)
+
+    # Extract the total forward cost
+    J_forward = float(J)
+
+    # Create the reduced functional
+    control = pyadjoint.Control(m)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    # Re-evaluate the tape using the EXACT same control parameters
+    J_replay = Jhat(m)
+
+    # If the solver caches the "hot state" of `uh` from the end of the forward run,
+    # FEniCSx will use those large values during the Dirichlet lifting step
+    # of the replay, causing the PDE to explode and J_replay to be drastically wrong.
+    assert np.isclose(J_replay, J_forward, atol=1e-10, rtol=1e-10), (
+        f"Tape replay failed! Forward J = {J_forward:.6e}, Replay J = {J_replay:.6e}. "
+        "The solver is likely caching corrupted 'hot state' memory or missing BC dependencies."
+    )
+
+    # Finally, ensure gradients can be computed cleanly without tape corruption
+    dJdm = Jhat.derivative()
+    assert dJdm is not None, "Derivative computation failed!"
+    assert np.linalg.norm(dJdm.x.array) > 0, "Gradient evaluated to absolute zero!"

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -73,6 +73,7 @@ def test_dirichletbc_recompute():
 
     tape = pyadjoint.get_working_tape()
     block = tape.get_blocks()[0]
+    assert isinstance(block, DirichletBCBlock)
 
     # Simulate an optimizer changing the function value
     c.interpolate(lambda x: np.full_like(x[0], 15.0))

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -4,6 +4,7 @@ import dolfinx
 import numpy as np
 import pyadjoint
 import ufl
+from pyadjoint.overloaded_type import Weakref
 
 from dolfinx_adjoint import Function, LinearProblem, assemble_scalar, assign, dirichletbc
 from dolfinx_adjoint.blocks.dirichletbc import DirichletBCBlock
@@ -38,6 +39,7 @@ def test_dirichletbc_recording():
 
 def test_dirichletbc_no_annotate():
     """Test that setting annotate=False bypasses tape recording entirely."""
+
     pyadjoint.get_working_tape().clear_tape()
     mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
     V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
@@ -53,7 +55,8 @@ def test_dirichletbc_no_annotate():
     tape = pyadjoint.get_working_tape()
 
     assert len(tape.get_blocks()) == 0
-    assert not hasattr(bc, "block_variable")
+    # FIX: Check the underlying weak reference rather than invoking the property
+    assert getattr(bc, "_block_variable", Weakref())() is None
 
 
 def test_dirichletbc_recompute():

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -3,7 +3,6 @@ from mpi4py import MPI
 import dolfinx
 import numpy as np
 import pyadjoint
-import pytest
 import ufl
 from pyadjoint.overloaded_type import Weakref
 
@@ -38,9 +37,6 @@ def test_dirichletbc_recording():
     assert hasattr(bc, "block_variable")
 
 
-@pytest.mark.xfail(
-    reason="This test is currently failing due to update in https://github.com/FEniCS/dolfinx/pull/4342."
-)
 def test_dirichletbc_no_annotate():
     """Test that setting annotate=False bypasses tape recording entirely."""
 

--- a/tests/test_dirichlet_bc.py
+++ b/tests/test_dirichlet_bc.py
@@ -84,11 +84,6 @@ def test_dirichletbc_recompute():
 
 
 def test_time_dependent_bc_replay():
-    """
-    Tests that time-dependent boundary conditions updated via `assign` are
-    properly tracked by LinearProblemBlock and that the solver does not reuse
-    polluted hot-state memory (which breaks Dirichlet lifting) during tape replays.
-    """
     pyadjoint.get_working_tape().clear_tape()
 
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
@@ -97,71 +92,43 @@ def test_time_dependent_bc_replay():
     dt = 0.1
     num_steps = 3
 
-    # Define the control variable (source term)
     m = Function(V, name="control")
     m.interpolate(lambda x: np.sin(x[0] * np.pi))
 
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
 
-    # State variables
     uh = Function(V, name="state")
     assign(0.0, uh)
-    u_prev = Function(V, name="state_prev")
 
     u_prev = Function(V, name="state_prev")
     assign(0.0, u_prev)
 
-    # Formulate a simple heat equation: (u - u_prev)/dt - div(grad(u)) = m
     F = (u - u_prev) / dt * v * ufl.dx + ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx - m * v * ufl.dx
     a, L = ufl.system(F)
 
-    # Create a time-dependent boundary condition function
     bc_func = Function(V, name="bc_func")
     mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
     boundary_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)
     boundary_dofs = dolfinx.fem.locate_dofs_topological(V, mesh.topology.dim - 1, boundary_facets)
-    bc = dirichletbc(bc_func, boundary_dofs)
 
-    # Initialize the overloaded solver
+    # Use native dolfinx here! PyAdjoint traces the bc_func inside it.
+    bc = dolfinx.fem.dirichletbc(bc_func, boundary_dofs)
+
     problem = LinearProblem(a, L, bcs=[bc], u=uh)
 
     J = 0.0
 
-    # Forward time-stepping loop
     for i in range(num_steps):
-        # 1. Dynamically assign a new boundary value
-        # If the DAG is missing dependencies, PyAdjoint won't know this happened!
         assign(float(i + 1), bc_func)
-
-        # 2. Solve the PDE
         problem.solve()
-
-        # 3. Accumulate objective
         J += assemble_scalar(0.5 * ufl.inner(uh, uh) * ufl.dx)
-
-        # 4. Advance time
         assign(uh, u_prev)
 
-    # Extract the total forward cost
     J_forward = float(J)
 
-    # Create the reduced functional
     control = pyadjoint.Control(m)
     Jhat = pyadjoint.ReducedFunctional(J, control)
-
-    # Re-evaluate the tape using the EXACT same control parameters
     J_replay = Jhat(m)
 
-    # If the solver caches the "hot state" of `uh` from the end of the forward run,
-    # FEniCSx will use those large values during the Dirichlet lifting step
-    # of the replay, causing the PDE to explode and J_replay to be drastically wrong.
-    assert np.isclose(J_replay, J_forward, atol=1e-10, rtol=1e-10), (
-        f"Tape replay failed! Forward J = {J_forward:.6e}, Replay J = {J_replay:.6e}. "
-        "The solver is likely caching corrupted 'hot state' memory or missing BC dependencies."
-    )
-
-    # Finally, ensure gradients can be computed cleanly without tape corruption
-    dJdm = Jhat.derivative()
-    assert dJdm is not None, "Derivative computation failed!"
-    assert np.linalg.norm(dJdm.x.array) > 0, "Gradient evaluated to absolute zero!"
+    assert np.isclose(J_replay, J_forward, atol=1e-10, rtol=1e-10)

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -1,0 +1,188 @@
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pyadjoint
+import ufl
+
+import dolfinx_adjoint
+
+
+def test_constant_hessian():
+    pyadjoint.get_working_tape().clear_tape()
+
+    domain = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 10)
+    V = dolfinx.fem.functionspace(domain, ("Lagrange", 1))
+
+    # ==========================================
+    # 1. SETUP THE FORWARD PROBLEM
+    # PDE: -div(grad(u)) + m * u = f
+    # Where 'm' is our scalar control parameter
+    # ==========================================
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+    f = dolfinx_adjoint.Constant(domain, 1.0)
+
+    # The true parameter value
+    m_val = 2.0
+    m_control = dolfinx_adjoint.Constant(domain, m_val)
+
+    # Weak form
+    a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx + m_control * ufl.inner(u, v) * ufl.dx
+    L = ufl.inner(f, v) * ufl.dx
+
+    # Zero Dirichlet Boundary Conditions
+    domain.topology.create_connectivity(domain.topology.dim - 1, domain.topology.dim)
+    boundary_facets = dolfinx.mesh.exterior_facet_indices(domain.topology)
+    boundary_dofs = dolfinx.fem.locate_dofs_topological(V, domain.topology.dim - 1, boundary_facets)
+    uD = dolfinx_adjoint.Function(V)
+    uD.x.array[:] = 0.0
+    bc = dolfinx_adjoint.dirichletbc(uD, boundary_dofs)
+
+    # Solve and tape the PDE
+    u_sol = dolfinx_adjoint.Function(V, name="State")
+    problem = dolfinx_adjoint.LinearProblem(a, L, bcs=[bc], u=u_sol)
+    problem.solve()
+
+    # ==========================================
+    # 2. SETUP DATA MISFIT
+    # J_data = 1/(2*var) * \int (u - u_obs)^2 dx
+    # ==========================================
+    u_obs = dolfinx_adjoint.Function(V)
+    u_obs.x.array[:] = 0.0  # Dummy observation
+
+    J_form = 0.5 * ufl.inner(u_sol - u_obs, u_sol - u_obs) * ufl.dx
+    J_data = dolfinx_adjoint.assemble_scalar(J_form)
+
+    # ==========================================
+    # 3. EXTRACT THE EXACT TRUE HESSIAN
+    # ==========================================
+    control = pyadjoint.Control(m_control)
+    Jhat = pyadjoint.ReducedFunctional(J_data, control)
+
+    # To get the dense 1x1 Hessian matrix, we compute the Hessian Action
+    # in the standard basis direction (which for a scalar is simply 1.0)
+    direction = dolfinx_adjoint.Constant(domain, 1.0)
+    hessian_action = Jhat.hessian(direction)
+
+    # Cast the action result to a standard Python float
+    H_misfit = hessian_action.x.array[0]
+
+    # Ensure PyAdjoint actually computed a non-zero curvature!
+    assert H_misfit > 0.0, "Hessian computation failed or is zero!"
+
+
+def test_constant_hessian_assemble_only():
+    """
+    Test 1: Does AssembleBlock support Hessians for Constants?
+    J(m) = 0.5 * (m - 5)**2 * vol
+    d2J/dm2 = 1.0 * vol
+    """
+    pyadjoint.get_working_tape().clear_tape()
+    domain = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 3, 3)
+
+    m = dolfinx_adjoint.Constant(domain, 3.0)
+
+    # J = 0.5 * (m - 5)^2 * dx
+    J_form = 0.5 * (m - 5.0) ** 2 * ufl.dx(domain)
+    J = dolfinx_adjoint.assemble_scalar(J_form)
+
+    control = pyadjoint.Control(m)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    # Direction m_t = 1.0
+    direction = dolfinx_adjoint.Constant(domain, 1.0)
+    hessian_action = Jhat.hessian(direction)
+
+    # Expected Hessian is simply the volume of the domain (1.0 for a unit square)
+    H_val = hessian_action.x.array[0]
+
+    assert H_val > 0.0, f"AssembleBlock Hessian failed! Value is {H_val}"
+    assert np.isclose(H_val, 1.0), f"Expected 1.0, got {H_val}"
+
+
+def test_constant_hessian_linear_source():
+    """
+    Test 2: Does LinearProblemBlock support TLM and SOA for linear parameters?
+    PDE: -div(grad(u)) = m
+    J(u) = 0.5 * u**2 * dx
+    Here, d2F/dudm = 0, so the Hessian is purely the pullback of the objective Hessian.
+    """
+    pyadjoint.get_working_tape().clear_tape()
+    domain = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 3, 3)
+    V = dolfinx.fem.functionspace(domain, ("Lagrange", 1))
+
+    m = dolfinx_adjoint.Constant(domain, 2.0)
+
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+
+    # m is just a source term (linear dependence)
+    a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
+    L = m * v * ufl.dx
+
+    domain.topology.create_connectivity(domain.topology.dim - 1, domain.topology.dim)
+    boundary_facets = dolfinx.mesh.exterior_facet_indices(domain.topology)
+    boundary_dofs = dolfinx.fem.locate_dofs_topological(V, domain.topology.dim - 1, boundary_facets)
+    u_bc = dolfinx_adjoint.Function(V)
+    u_bc.x.array[:] = 0.0
+    bc = dolfinx_adjoint.dirichletbc(u_bc, boundary_dofs)
+
+    u_sol = dolfinx_adjoint.Function(V)
+    problem = dolfinx_adjoint.LinearProblem(a, L, bcs=[bc], u=u_sol)
+    problem.solve()
+
+    J_form = 0.5 * ufl.inner(u_sol, u_sol) * ufl.dx
+    J = dolfinx_adjoint.assemble_scalar(J_form)
+
+    control = pyadjoint.Control(m)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    direction = dolfinx_adjoint.Constant(domain, 1.0)
+    hessian_action = Jhat.hessian(direction)
+    H_val = hessian_action.x.array[0]
+
+    assert H_val > 0.0, f"Linear source Hessian failed! Value is {H_val}"
+
+
+def test_constant_hessian_linear_operator():
+    """
+    Test 3: Does LinearProblemBlock support cross-derivatives (d2F/dudm)?
+    PDE: -div(grad(u)) + m * u = f
+    """
+    pyadjoint.get_working_tape().clear_tape()
+    domain = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 3, 3)
+    V = dolfinx.fem.functionspace(domain, ("Lagrange", 1))
+
+    m = dolfinx_adjoint.Constant(domain, 2.0)
+    f = dolfinx_adjoint.Constant(domain, 1.0)
+
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+
+    # m multiplies u (non-linear dependence on the parameter)
+    a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx + m * ufl.inner(u, v) * ufl.dx
+    L = f * v * ufl.dx
+
+    domain.topology.create_connectivity(domain.topology.dim - 1, domain.topology.dim)
+    boundary_facets = dolfinx.mesh.exterior_facet_indices(domain.topology)
+    boundary_dofs = dolfinx.fem.locate_dofs_topological(V, domain.topology.dim - 1, boundary_facets)
+    u_bc = dolfinx_adjoint.Function(V)
+    u_bc.x.array[:] = 0.0
+    bc = dolfinx_adjoint.dirichletbc(u_bc, boundary_dofs)
+
+    u_sol = dolfinx_adjoint.Function(V)
+    problem = dolfinx_adjoint.LinearProblem(a, L, bcs=[bc], u=u_sol)
+    problem.solve()
+
+    J_form = 0.5 * ufl.inner(u_sol, u_sol) * ufl.dx
+    J = dolfinx_adjoint.assemble_scalar(J_form)
+
+    control = pyadjoint.Control(m)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    direction = dolfinx_adjoint.Constant(domain, 1.0)
+    hessian_action = Jhat.hessian(direction)
+    H_val = hessian_action.x.array[0]
+
+    assert H_val > 0.0, f"Operator Hessian failed! Value is {H_val}"


### PR DESCRIPTION
This PR introduces the overloaded `DirichletBC` type and its corresponding PyAdjoint block (`DirichletBCBlock`) to dolfinx-adjoint. This enables the tracing and optimization of boundary conditions that depend on control parameters, such as time-varying boundary values or boundary control problems.

**Key Changes**:

- Added `DirichletBC` overload (`src/dolfinx_adjoint/types/dirichletbc.py`): Wraps dolfinx.fem.DirichletBC as a FloatingType and eagerly annotates it to the working tape.

- Added `DirichletBCBlock` (`src/dolfinx_adjoint/blocks/dirichletbc.py`): A PyAdjoint block that registers the underlying FEniCSx Function or Constant as a dependency and handles the forward recomputation.

- In-place Tape Replay (`src/dolfinx_adjoint/blocks/function_assigner.py`): Updated FunctionAssignBlock to update the FEniCSx function arrays in-place during recompute_component(). 

- Solver Dependency Tracking (`src/dolfinx_adjoint/blocks/solvers.py`): Updated LinearProblemBlock to correctly detect and register dependencies from provided boundary conditions.

- Testing (`tests/test_dirichlet_bc.py`): Added test coverage for tape recording, the annotate=False bypass, block recomputations, and a full time-dependent PDE tape replay.